### PR TITLE
Declare install requirements.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -115,6 +115,10 @@ dependency_links =
 package_dir=
     =src
 packages=find:
+install_requires =
+    docutils
+    sphinx>2.0.0
+    sphinx-prompt>=0.1
 
 [options.packages.find]
 where=src


### PR DESCRIPTION
Hi! Always good when I need something and find it, doubly so when it ends up being ClusterHQ/people I know-related. Hope all's well!

Sending a PR to declare the install requirements in a way that'll get installed when `pip installing` this as a dependency.

Previously, trying to enable this extension on a project that didn't
already depend on sphinx-prompt would error out with:

        _EXISTING_PROMPT_DIRECTIVE: Directive = _EXISTING_DIRECTIVES['prompt']
    KeyError: 'prompt'

tracebacks given that the directive wasn't installed at install-time.