### PR TITLE
Ensure non-lower-case replacements can also be substituted

### DIFF
--- a/src/sphinx_substitution_extensions/__init__.py
+++ b/src/sphinx_substitution_extensions/__init__.py
@@ -53,9 +53,9 @@ class SubstitutionCodeBlock(_EXISTING_CODE_BLOCK_DIRECTIVE):  # type: ignore
         existing_content = self.content
         substitution_defs = self.state.document.substitution_defs
         for item in existing_content:
-            for name in self.state.document.substitution_names:
+            for name, value in substitution_defs.items():
                 if _SUBSTITUTION_OPTION_NAME in self.options:
-                    replacement = substitution_defs[name].astext()
+                    replacement = value.astext()
                     item = item.replace(
                         '|{original}|'.format(original=name),
                         replacement,
@@ -87,9 +87,9 @@ class SubstitutionPrompt(_EXISTING_PROMPT_DIRECTIVE):  # type: ignore
         existing_content = self.content
         substitution_defs = self.state.document.substitution_defs
         for item in existing_content:
-            for name in self.state.document.substitution_names:
+            for name, value in substitution_defs.items():
                 if _SUBSTITUTION_OPTION_NAME in self.options:
-                    replacement = substitution_defs[name].astext()
+                    replacement = value.astext()
                     item = item.replace(
                         '|{original}|'.format(original=name),
                         replacement,

--- a/tests/test_substitution_extensions.py
+++ b/tests/test_substitution_extensions.py
@@ -3,6 +3,7 @@ Tests for Sphinx extensions.
 """
 
 import subprocess
+import sys
 from pathlib import Path
 from textwrap import dedent
 
@@ -26,7 +27,7 @@ def test_prompt_specified_late(tmp_path: Path) -> None:
     conf_py.write_text(conf_py_content)
     destination_directory = tmp_path / 'destination'
     args = [
-        'sphinx-build',
+        sys.executable, "-m", "sphinx",
         '-b',
         'html',
         '-W',
@@ -83,7 +84,7 @@ def test_substitution_prompt(tmp_path: Path) -> None:
     source_file.write_text(source_file_content)
     destination_directory = tmp_path / 'destination'
     args = [
-        'sphinx-build',
+        sys.executable, "-m", "sphinx",
         '-b',
         'html',
         '-W',
@@ -130,7 +131,7 @@ def test_no_substitution_prompt(tmp_path: Path) -> None:
     source_file.write_text(source_file_content)
     destination_directory = tmp_path / 'destination'
     args = [
-        'sphinx-build',
+        sys.executable, "-m", "sphinx",
         '-b',
         'html',
         '-W',
@@ -177,7 +178,7 @@ def test_no_substitution_code_block(tmp_path: Path) -> None:
     source_file.write_text(source_file_content)
     destination_directory = tmp_path / 'destination'
     args = [
-        'sphinx-build',
+        sys.executable, "-m", "sphinx",
         '-b',
         'html',
         '-W',
@@ -225,7 +226,7 @@ def test_substitution_code_block(tmp_path: Path) -> None:
     source_file.write_text(source_file_content)
     destination_directory = tmp_path / 'destination'
     args = [
-        'sphinx-build',
+        sys.executable, "-m", "sphinx",
         '-b',
         'html',
         '-W',
@@ -270,7 +271,7 @@ def test_substitution_inline(tmp_path: Path) -> None:
     source_file.write_text(source_file_content)
     destination_directory = tmp_path / 'destination'
     args = [
-        'sphinx-build',
+        sys.executable, "-m", "sphinx",
         '-b',
         'html',
         '-W',

--- a/tests/test_substitution_extensions.py
+++ b/tests/test_substitution_extensions.py
@@ -101,6 +101,53 @@ def test_substitution_prompt(tmp_path: Path) -> None:
     assert expected in content_html.read_text()
 
 
+def test_substitution_prompt_is_case_preserving(tmp_path: Path) -> None:
+    """
+    The ``prompt`` directive respects the original case of replacements.
+    """
+    source_directory = tmp_path / 'source'
+    source_directory.mkdir()
+    source_file = source_directory / 'index.rst'
+    conf_py = source_directory / 'conf.py'
+    conf_py.touch()
+    source_file.touch()
+    conf_py_content = dedent(
+        """\
+        extensions = ['sphinx-prompt', 'sphinx_substitution_extensions']
+        rst_prolog = '''
+        .. |aBcD_eFgH| replace:: example_substitution
+        '''
+        """,
+    )
+    conf_py.write_text(conf_py_content)
+    source_file_content = dedent(
+        """\
+        .. prompt:: bash $
+           :substitutions:
+
+           $ PRE-|aBcD_eFgH|-POST
+        """,
+    )
+    source_file.write_text(source_file_content)
+    destination_directory = tmp_path / 'destination'
+    args = [
+        sys.executable, "-m", "sphinx",
+        '-b',
+        'html',
+        '-W',
+        # Directory containing source and configuration files.
+        str(source_directory),
+        # Directory containing build files.
+        str(destination_directory),
+        # Source file to process.
+        str(source_file),
+    ]
+    subprocess.check_output(args=args)
+    expected = 'PRE-example_substitution-POST'
+    content_html = Path(str(destination_directory)) / 'index.html'
+    assert expected in content_html.read_text()
+
+
 def test_no_substitution_prompt(tmp_path: Path) -> None:
     """
     The ``prompt`` directive does not replace the placeholders defined in
@@ -221,6 +268,53 @@ def test_substitution_code_block(tmp_path: Path) -> None:
            :substitutions:
 
            $ PRE-|a|-POST
+        """,
+    )
+    source_file.write_text(source_file_content)
+    destination_directory = tmp_path / 'destination'
+    args = [
+        sys.executable, "-m", "sphinx",
+        '-b',
+        'html',
+        '-W',
+        # Directory containing source and configuration files.
+        str(source_directory),
+        # Directory containing build files.
+        str(destination_directory),
+        # Source file to process.
+        str(source_file),
+    ]
+    subprocess.check_output(args=args)
+    expected = 'PRE-example_substitution-POST'
+    content_html = Path(str(destination_directory)) / 'index.html'
+    assert expected in content_html.read_text()
+
+
+def test_substitution_code_block_case_preserving(tmp_path: Path) -> None:
+    """
+    The ``code-block`` directive respects the original case of replacements.
+    """
+    source_directory = tmp_path / 'source'
+    source_directory.mkdir()
+    source_file = source_directory / 'index.rst'
+    conf_py = source_directory / 'conf.py'
+    conf_py.touch()
+    source_file.touch()
+    conf_py_content = dedent(
+        """\
+        extensions = ['sphinx-prompt', 'sphinx_substitution_extensions']
+        rst_prolog = '''
+        .. |aBcD_eFgH| replace:: example_substitution
+        '''
+        """,
+    )
+    conf_py.write_text(conf_py_content)
+    source_file_content = dedent(
+        """\
+        .. code-block:: bash
+           :substitutions:
+
+           $ PRE-|aBcD_eFgH|-POST
         """,
     )
     source_file.write_text(source_file_content)

--- a/tests/test_substitution_extensions.py
+++ b/tests/test_substitution_extensions.py
@@ -27,7 +27,9 @@ def test_prompt_specified_late(tmp_path: Path) -> None:
     conf_py.write_text(conf_py_content)
     destination_directory = tmp_path / 'destination'
     args = [
-        sys.executable, "-m", "sphinx",
+        sys.executable,
+        '-m',
+        'sphinx',
         '-b',
         'html',
         '-W',
@@ -84,7 +86,9 @@ def test_substitution_prompt(tmp_path: Path) -> None:
     source_file.write_text(source_file_content)
     destination_directory = tmp_path / 'destination'
     args = [
-        sys.executable, "-m", "sphinx",
+        sys.executable,
+        '-m',
+        'sphinx',
         '-b',
         'html',
         '-W',
@@ -131,7 +135,9 @@ def test_substitution_prompt_is_case_preserving(tmp_path: Path) -> None:
     source_file.write_text(source_file_content)
     destination_directory = tmp_path / 'destination'
     args = [
-        sys.executable, "-m", "sphinx",
+        sys.executable,
+        '-m',
+        'sphinx',
         '-b',
         'html',
         '-W',
@@ -178,7 +184,9 @@ def test_no_substitution_prompt(tmp_path: Path) -> None:
     source_file.write_text(source_file_content)
     destination_directory = tmp_path / 'destination'
     args = [
-        sys.executable, "-m", "sphinx",
+        sys.executable,
+        '-m',
+        'sphinx',
         '-b',
         'html',
         '-W',
@@ -225,7 +233,9 @@ def test_no_substitution_code_block(tmp_path: Path) -> None:
     source_file.write_text(source_file_content)
     destination_directory = tmp_path / 'destination'
     args = [
-        sys.executable, "-m", "sphinx",
+        sys.executable,
+        '-m',
+        'sphinx',
         '-b',
         'html',
         '-W',
@@ -273,7 +283,9 @@ def test_substitution_code_block(tmp_path: Path) -> None:
     source_file.write_text(source_file_content)
     destination_directory = tmp_path / 'destination'
     args = [
-        sys.executable, "-m", "sphinx",
+        sys.executable,
+        '-m',
+        'sphinx',
         '-b',
         'html',
         '-W',
@@ -320,7 +332,9 @@ def test_substitution_code_block_case_preserving(tmp_path: Path) -> None:
     source_file.write_text(source_file_content)
     destination_directory = tmp_path / 'destination'
     args = [
-        sys.executable, "-m", "sphinx",
+        sys.executable,
+        '-m',
+        'sphinx',
         '-b',
         'html',
         '-W',
@@ -365,7 +379,9 @@ def test_substitution_inline(tmp_path: Path) -> None:
     source_file.write_text(source_file_content)
     destination_directory = tmp_path / 'destination'
     args = [
-        sys.executable, "-m", "sphinx",
+        sys.executable,
+        '-m',
+        'sphinx',
         '-b',
         'html',
         '-W',


### PR DESCRIPTION
This patch ensures non-fully-lower-case replacements can also be substituted.

Previously, I was getting `KeyError` exceptions if a non-lowercase substitution even existed (regardless of whether it was being substituted).