### PR TITLE
Add Sphinx Extension classifier

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,7 @@ license = Apache License, Version 2.0
 classifiers =
     Operating System :: POSIX
     Environment :: Web Environment
+    Framework :: Sphinx :: Extension
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11


### PR DESCRIPTION
Add the Sphinx Extension PyPi classifier so that the extension shows up in the correct [PyPi filters](https://pypi.org/search/?c=Framework+%3A%3A+Sphinx+%3A%3A+Extension).