### PR TITLE
Use modern setup_extension system to extend sphinx-prompt, making it …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           # We use '--ignore-installed' to avoid GitHub's cache which can cause
           # issues - we have seen packages from this cache be cause trouble with
           # pip-extra-reqs.
-          python -m pip install --ignore-installed --upgrade --editable .[dev,prompt]
+          python -m pip install --ignore-installed --upgrade --editable .[dev]
 
       - name: "Lint"
         run: |

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Next
 
 - Bump the minimum supported version of Sphinx to 5.1.1.
 - Bump the minimum supported version of docutils to 0.19.
+- Remove the need to specify the ``sphinx-prompt`` extension in ``conf.py`` in order to use the ``prompt`` directive.
 
 2022.02.16
 ------------

--- a/README.rst
+++ b/README.rst
@@ -41,20 +41,11 @@ Optional: sphinx-prompt
 
 Sphinx Substitution Extensions supports the third-party extension `sphinx-prompt`_.
 
-1. If you don't have ``sphinx-prompt`` installed, you can include the extension with the extra dependency ``prompt``:
+If you don't have ``sphinx-prompt`` installed, you can include the extension with the extra dependency ``prompt``:
 
 .. code:: console
 
    $ pip install Sphinx-Substitution-Extensions[prompt]
-
-
-2. Make sure ``sphinx-prompt`` dependency is loaded before ``sphinx_substitution_extensions``.
-For example, your ``conf.py`` should look like:
-
-.. code:: python
-
-   # sphinx-prompt must be the first of these two.
-   extensions += ['sphinx-prompt', 'sphinx_substitution_extensions']
 
 Directives
 ----------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,6 +208,7 @@ dependencies = [
     # The lowest versions of these are matched in the ``.github/workflows/ci-versions.yml`` workflow.
     "docutils>=0.19",
     "sphinx>=5.1.1",
+	"sphinx-prompt>=0.1",
 ]
 
 [project.optional-dependencies]
@@ -228,7 +229,10 @@ dev = [
     "types-docutils==0.20.0.3",
     "vulture==2.8",
 ]
-prompt = ["sphinx-prompt>=0.1"]
+# We used to have "sphinx-prompt" as an optional extra.
+# We keep this optional-dependencies block here so as not to break anyone who
+# used that extra.
+prompt = []
 
 [project.urls]
 Source = "https://github.com/adamtheturtle/sphinx-substitution-extensions"

--- a/sample/source/conf.py
+++ b/sample/source/conf.py
@@ -3,7 +3,6 @@ Sample ``conf.py``.
 """
 
 extensions = [
-    "sphinx-prompt",
     "sphinx_substitution_extensions",
 ]
 

--- a/src/sphinx_substitution_extensions/__init__.py
+++ b/src/sphinx_substitution_extensions/__init__.py
@@ -11,6 +11,7 @@ from docutils.parsers.rst import directives
 from docutils.parsers.rst.roles import code_role
 from sphinx.directives.code import CodeBlock
 
+from sphinx_substitution_extensions.extras import SubstitutionPrompt
 from sphinx_substitution_extensions.shared import (
     SUBSTITUTION_OPTION_NAME,
 )
@@ -51,19 +52,6 @@ class SubstitutionCodeBlock(CodeBlock):
 
         self.content = new_content
         return list(super().run())
-
-
-def _exists_dependency(
-    name: str,
-) -> bool:
-    """
-    Returns true if the dependency is installed.
-    """
-    try:
-        __import__(name)
-    except ImportError:
-        return False
-    return True
 
 
 def substitution_code_role(  # pylint: disable=dangerous-default-value
@@ -113,10 +101,7 @@ def setup(app: Sphinx) -> dict[str, Any]:
     """
     app.add_config_value("substitutions", [], "html")
     directives.register_directive("code-block", SubstitutionCodeBlock)
-    if _exists_dependency("sphinx-prompt"):
-        app.setup_extension("sphinx-prompt")
-        from sphinx_substitution_extensions.extras import SubstitutionPrompt
-
-        directives.register_directive("prompt", SubstitutionPrompt)
+    app.setup_extension("sphinx-prompt")
+    directives.register_directive("prompt", SubstitutionPrompt)
     app.add_role("substitution-code", substitution_code_role)
     return {"parallel_read_safe": True}

--- a/src/sphinx_substitution_extensions/__init__.py
+++ b/src/sphinx_substitution_extensions/__init__.py
@@ -11,7 +11,6 @@ from docutils.parsers.rst import directives
 from docutils.parsers.rst.roles import code_role
 from sphinx.directives.code import CodeBlock
 
-from sphinx_substitution_extensions.extras import SubstitutionPrompt
 from sphinx_substitution_extensions.shared import (
     SUBSTITUTION_OPTION_NAME,
 )
@@ -102,6 +101,13 @@ def setup(app: Sphinx) -> dict[str, Any]:
     app.add_config_value("substitutions", [], "html")
     directives.register_directive("code-block", SubstitutionCodeBlock)
     app.setup_extension("sphinx-prompt")
+    # We delay the import of `SubstitutionPrompt` until after we have set up
+    # the "sphinx-prompt" extension, else the `SubstitutionPrompt` may be
+    # depending on something which does not yet exist.
+    # pylint: disable=import-outside-toplevel
+    from sphinx_substitution_extensions.extras import SubstitutionPrompt
+
     directives.register_directive("prompt", SubstitutionPrompt)
+
     app.add_role("substitution-code", substitution_code_role)
     return {"parallel_read_safe": True}

--- a/src/sphinx_substitution_extensions/__init__.py
+++ b/src/sphinx_substitution_extensions/__init__.py
@@ -12,7 +12,6 @@ from docutils.parsers.rst.roles import code_role
 from sphinx.directives.code import CodeBlock
 
 from sphinx_substitution_extensions.shared import (
-    EXISTING_DIRECTIVES,
     SUBSTITUTION_OPTION_NAME,
 )
 
@@ -107,13 +106,6 @@ substitution_code_role.options = {  # type: ignore[attr-defined]
     "language": directives.unchanged,
 }
 
-if _exists_dependency("sphinx-prompt") and "prompt" not in EXISTING_DIRECTIVES:
-    MESSAGE = (
-        "sphinx-prompt must be in the conf.py extensions list before "
-        "sphinx_substitution_extensions"
-    )
-    LOGGER.warning(MESSAGE)
-
 
 def setup(app: Sphinx) -> dict[str, Any]:
     """
@@ -122,7 +114,8 @@ def setup(app: Sphinx) -> dict[str, Any]:
     # pylint: disable=import-outside-toplevel
     app.add_config_value("substitutions", [], "html")
     directives.register_directive("code-block", SubstitutionCodeBlock)
-    if "prompt" in EXISTING_DIRECTIVES:
+    if _exists_dependency("sphinx-prompt"):
+        app.setup_extension("sphinx-prompt")
         from sphinx_substitution_extensions.extras import SubstitutionPrompt
 
         directives.register_directive("prompt", SubstitutionPrompt)

--- a/src/sphinx_substitution_extensions/__init__.py
+++ b/src/sphinx_substitution_extensions/__init__.py
@@ -111,7 +111,6 @@ def setup(app: Sphinx) -> dict[str, Any]:
     """
     Add the custom directives to Sphinx.
     """
-    # pylint: disable=import-outside-toplevel
     app.add_config_value("substitutions", [], "html")
     directives.register_directive("code-block", SubstitutionCodeBlock)
     if _exists_dependency("sphinx-prompt"):

--- a/src/sphinx_substitution_extensions/__init__.py
+++ b/src/sphinx_substitution_extensions/__init__.py
@@ -11,6 +11,7 @@ from docutils.parsers.rst import directives
 from docutils.parsers.rst.roles import code_role
 from sphinx.directives.code import CodeBlock
 
+from sphinx_substitution_extensions.extras import SubstitutionPrompt
 from sphinx_substitution_extensions.shared import (
     SUBSTITUTION_OPTION_NAME,
 )
@@ -101,13 +102,6 @@ def setup(app: Sphinx) -> dict[str, Any]:
     app.add_config_value("substitutions", [], "html")
     directives.register_directive("code-block", SubstitutionCodeBlock)
     app.setup_extension("sphinx-prompt")
-    # We delay the import of `SubstitutionPrompt` until after we have set up
-    # the "sphinx-prompt" extension, else the `SubstitutionPrompt` may be
-    # depending on something which does not yet exist.
-    # pylint: disable=import-outside-toplevel
-    from sphinx_substitution_extensions.extras import SubstitutionPrompt
-
     directives.register_directive("prompt", SubstitutionPrompt)
-
     app.add_role("substitution-code", substitution_code_role)
     return {"parallel_read_safe": True}

--- a/src/sphinx_substitution_extensions/extras.py
+++ b/src/sphinx_substitution_extensions/extras.py
@@ -8,14 +8,15 @@ from typing import TYPE_CHECKING
 from docutils.parsers.rst import Directive, directives
 
 from sphinx_substitution_extensions.shared import (
-    EXISTING_DIRECTIVES,
     SUBSTITUTION_OPTION_NAME,
 )
 
 if TYPE_CHECKING:
     from docutils.nodes import raw
 
-_EXISTING_PROMPT_DIRECTIVE: Directive = EXISTING_DIRECTIVES["prompt"]
+_EXISTING_DIRS = directives._directives  # noqa: SLF001
+_EXISTING_DIRECTIVES: dict[str, Directive] = _EXISTING_DIRS
+_EXISTING_PROMPT_DIRECTIVE: Directive = _EXISTING_DIRECTIVES["prompt"]
 
 
 class SubstitutionPrompt(_EXISTING_PROMPT_DIRECTIVE):  # type: ignore[misc, valid-type]

--- a/src/sphinx_substitution_extensions/extras.py
+++ b/src/sphinx_substitution_extensions/extras.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from docutils.parsers.rst import Directive, directives
+from docutils.parsers.rst import directives
 
 from sphinx_substitution_extensions.shared import (
     SUBSTITUTION_OPTION_NAME,
@@ -14,17 +14,17 @@ from sphinx_substitution_extensions.shared import (
 if TYPE_CHECKING:
     from docutils.nodes import raw
 
-_EXISTING_DIRS = directives._directives  # noqa: SLF001
-_EXISTING_DIRECTIVES: dict[str, Directive] = _EXISTING_DIRS
-_EXISTING_PROMPT_DIRECTIVE: Directive = _EXISTING_DIRECTIVES["prompt"]
+
+sphinx_prompt = __import__("sphinx-prompt")
+PromptDirective = sphinx_prompt.PromptDirective
 
 
-class SubstitutionPrompt(_EXISTING_PROMPT_DIRECTIVE):  # type: ignore[misc, valid-type]
+class SubstitutionPrompt(PromptDirective):  # type: ignore[misc, valid-type]
     """
     Similar to PromptDirective but replaces placeholders with variables.
     """
 
-    option_spec = _EXISTING_PROMPT_DIRECTIVE.option_spec or {}
+    option_spec = PromptDirective.option_spec or {}
     option_spec["substitutions"] = directives.flag
 
     def run(self) -> list[raw]:

--- a/src/sphinx_substitution_extensions/shared.py
+++ b/src/sphinx_substitution_extensions/shared.py
@@ -2,11 +2,6 @@
 Constants and functions shared between modules.
 """
 
-from docutils.parsers.rst import Directive, directives
-
-EXISTING_DIRS = directives._directives  # noqa: SLF001
-EXISTING_DIRECTIVES: dict[str, Directive] = EXISTING_DIRS
-
 # This is hardcoded in doc8 as a valid option so be wary that changing this
 # may break doc8 linting.
 # See https://github.com/PyCQA/doc8/pull/34.

--- a/tests/test_substitution_extensions.py
+++ b/tests/test_substitution_extensions.py
@@ -7,8 +7,6 @@ import sys
 from pathlib import Path
 from textwrap import dedent
 
-from sphinx_substitution_extensions import _exists_dependency
-
 
 def test_no_substitution_code_block(tmp_path: Path) -> None:
     """
@@ -249,19 +247,3 @@ def test_substitution_inline_case_preserving(tmp_path: Path) -> None:
     expected = "PRE-example_substitution-POST"
     content_html = Path(str(destination_directory)) / "index.html"
     assert expected in content_html.read_text()
-
-
-def test_exists_dependency() -> None:
-    """
-    Test exist_dependency function.
-    """
-    dependency = "sphinx_substitution_extensions"
-    assert _exists_dependency(dependency) is True
-
-
-def test_does_not_exists_dependency() -> None:
-    """
-    Test exist_dependency function.
-    """
-    dependency = "fake_sphinx_substitution_extensions"
-    assert _exists_dependency(dependency) is False

--- a/tests/test_substitution_extensions_extras.py
+++ b/tests/test_substitution_extensions_extras.py
@@ -16,100 +16,6 @@ _REASON = "requires sphinx-prompt to be installed"
 pytestmark = [pytest.mark.skipif(not _EXISTS_PROMPT_EXTENSION, reason=_REASON)]
 
 
-def test_prompt_specified_late(tmp_path: Path) -> None:
-    """
-    If sphinx-prompt is not specified in extensions before Sphinx substitution
-    extensions, an warning is given.
-    """
-    source_directory = tmp_path / "source"
-    source_directory.mkdir()
-    source_file = source_directory / "index.rst"
-    conf_py = source_directory / "conf.py"
-    conf_py.touch()
-    source_file.touch()
-    conf_py_content = dedent(
-        """\
-        extensions = ['sphinx_substitution_extensions', 'sphinx-prompt']
-        """,
-    )
-    conf_py.write_text(conf_py_content)
-    destination_directory = tmp_path / "destination"
-    args = [
-        sys.executable,
-        "-m",
-        "sphinx",
-        "-b",
-        "html",
-        "-W",
-        # Directory containing source and configuration files.
-        str(source_directory),
-        # Directory containing build files.
-        str(destination_directory),
-        # Source file to process.
-        str(source_file),
-    ]
-    result = subprocess.run(
-        args=args,
-        check=False,
-        stderr=subprocess.PIPE,
-    )
-
-    expected_message = (
-        "sphinx-prompt must be in the conf.py extensions list before "
-        "sphinx_substitution_extensions"
-    )
-
-    assert result.returncode == 0  # Do not raise an error
-    assert expected_message in result.stderr.decode()
-
-
-def test_prompt_not_specified(tmp_path: Path) -> None:
-    """
-    If sphinx-prompt is not specified in extensions but is installed,
-    a warning is given.
-    """
-    source_directory = tmp_path / "source"
-    source_directory.mkdir()
-    source_file = source_directory / "index.rst"
-    conf_py = source_directory / "conf.py"
-    conf_py.touch()
-    source_file.touch()
-    conf_py_content = dedent(
-        """\
-        extensions = ['sphinx_substitution_extensions']
-        """,
-    )
-    conf_py.write_text(conf_py_content)
-    destination_directory = tmp_path / "destination"
-    args = [
-        sys.executable,
-        "-m",
-        "sphinx",
-        "-b",
-        "html",
-        "-W",
-        # Directory containing source and configuration files.
-        str(source_directory),
-        # Directory containing build files.
-        str(destination_directory),
-        # Source file to process.
-        str(source_file),
-    ]
-    result = subprocess.run(
-        args=args,
-        check=False,
-        stderr=subprocess.PIPE,
-    )
-
-    expected_message = (
-        "sphinx-prompt must be in the conf.py extensions list before "
-        "sphinx_substitution_extensions"
-    )
-
-    assert result.returncode == 0  # Do not raise an error
-    assert expected_message in result.stderr.decode()
-
-
 def test_substitution_prompt(tmp_path: Path) -> None:
     """
     The ``prompt`` directive replaces the placeholders defined in ``conf.py``
@@ -123,7 +29,7 @@ def test_substitution_prompt(tmp_path: Path) -> None:
     source_file.touch()
     conf_py_content = dedent(
         """\
-        extensions = ['sphinx-prompt', 'sphinx_substitution_extensions']
+        extensions = ['sphinx_substitution_extensions']
         rst_prolog = '''
         .. |a| replace:: example_substitution
         '''
@@ -172,7 +78,7 @@ def test_substitution_prompt_is_case_preserving(tmp_path: Path) -> None:
     source_file.touch()
     conf_py_content = dedent(
         """\
-        extensions = ['sphinx-prompt', 'sphinx_substitution_extensions']
+        extensions = ['sphinx_substitution_extensions']
         rst_prolog = '''
         .. |aBcD_eFgH| replace:: example_substitution
         '''
@@ -222,7 +128,7 @@ def test_no_substitution_prompt(tmp_path: Path) -> None:
     source_file.touch()
     conf_py_content = dedent(
         """\
-        extensions = ['sphinx-prompt', 'sphinx_substitution_extensions']
+        extensions = ['sphinx_substitution_extensions']
         rst_prolog = '''
         .. |a| replace:: example_substitution
         '''

--- a/tests/test_substitution_extensions_extras.py
+++ b/tests/test_substitution_extensions_extras.py
@@ -7,14 +7,6 @@ import sys
 from pathlib import Path
 from textwrap import dedent
 
-import pytest
-from sphinx_substitution_extensions import _exists_dependency
-
-_EXISTS_PROMPT_EXTENSION = _exists_dependency("sphinx-prompt")
-_REASON = "requires sphinx-prompt to be installed"
-
-pytestmark = [pytest.mark.skipif(not _EXISTS_PROMPT_EXTENSION, reason=_REASON)]
-
 
 def test_substitution_prompt(tmp_path: Path) -> None:
     """


### PR DESCRIPTION
…so that it doesn't have to be specified in conf.py

For the first time, this adds a required dependency which we do not expect all users to have already installed. I am not thrilled about that, but this allows us to dramatically simplify the codebase here and in a follow-up.