### PR TITLE
Fix issue in sample - we were giving `rest-example` a language which …

### DIFF
--- a/sample/source/index.rst
+++ b/sample/source/index.rst
@@ -33,7 +33,7 @@ Inline ``:code:``
 Inline ``:download:``
 ---------------------
 
-.. rest-example:: rst
+.. rest-example::
 
    .. We cannot use the substitution in the download target, because the download directive will error if the file does not exist.
 


### PR DESCRIPTION
…was interpreted as content