### PR TITLE
Remove unnecessary line that could cause unintended substitutions

### DIFF
--- a/src/sphinx_substitution_extensions/__init__.py
+++ b/src/sphinx_substitution_extensions/__init__.py
@@ -208,7 +208,6 @@ class SubstitutionCodeRole:
                     f"{opening_delimiter}{name}{closing_delimiter}",
                     value,
                 )
-                rawtext = rawtext.replace(name, value)
 
         # ``types-docutils`` says that ``code_role`` requires an ``Inliner``
         # for ``inliner``.


### PR DESCRIPTION
Line 211 in the SubstitutionCodeRole.__call__ method was performing an unnecessary and potentially problematic substitution.

The line `rawtext = rawtext.replace(name, value)` was:
1. Redundant - the proper delimiter-based replacement already happened on lines 207-210
2. Potentially incorrect - it replaces the bare name without delimiters, which could match partial strings that shouldn't be replaced

This fix removes the unnecessary line to prevent unintended substitutions.