### PR TITLE
Bump beartype to 0.22.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dynamic = [
     "version",
 ]
 dependencies = [
-    "beartype>=0.18.5",
+    "beartype>=0.22.9",
     "docutils>=0.19",
     "myst-parser>=4.0.0",
     "sphinx>=8.1.0",


### PR DESCRIPTION
Bump beartype dependency to 0.22.9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update `beartype` dependency in `pyproject.toml` from `>=0.18.5` to `>=0.22.9`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c48b0341bf4bec15ebdcc5e020fbe1a0b8a810e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->