### PR TITLE
Add ty to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,8 @@ ci:
     - pyright
     - pyright-docs
     - pyright-verifytypes
+    - ty
+    - ty-docs
     - pyroma
     - ruff-check-fix
     - ruff-check-fix-docs
@@ -188,6 +190,24 @@ repos:
         language: python
         pass_filenames: false
         types_or: [python]
+        additional_dependencies: [uv==0.9.5]
+
+      - id: ty
+        name: ty
+        stages: [pre-push]
+        entry: uv run --extra=dev ty check
+        language: python
+        types_or: [python, toml]
+        pass_filenames: false
+        additional_dependencies: [uv==0.9.5]
+
+      - id: ty-docs
+        name: ty-docs
+        stages: [pre-push]
+        entry: uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python
+          --command="ty check"
+        language: python
+        types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
 
       - id: vulture

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ optional-dependencies.dev = [
     "shfmt-py==3.12.0.2",
     "sphinx-lint==1.0.2",
     "sphinx-toolbox==4.1.0",
+    "ty==0.0.1a34",
     "types-docutils==0.22.3.20251115",
     "vulture==2.14",
     "yamlfix==1.19.0",


### PR DESCRIPTION
Add ty and ty-docs hooks to pre-commit configuration.

This adds type checking with ty, following the pattern established in other repositories.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add ty/ty-docs pre-push hooks and include ty in dev dependencies.
> 
> - **Pre-commit**:
>   - Add `ty` (`uv run --extra=dev ty check`) and `ty-docs` (`doccmd ... --command="ty check"`) hooks at `pre-push`.
>   - Update CI skip list to include `ty` and `ty-docs`.
> - **Dependencies**:
>   - Add `ty==0.0.1a34` to `optional-dependencies.dev` in `pyproject.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2fbea5c6038db6ec84d9772fa68a01d309b6fd1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->