### PR TITLE
Fix release.yml: remove persist-credentials that breaks git-auto-commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          persist-credentials: false
           # See
           # https://github.com/stefanzweifel/git-auto-commit-action?tab=readme-ov-file#push-to-protected-branches
           token: ${{ secrets.RELEASE_PAT }}

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -10,3 +10,5 @@ rules:
     disable: true
   template-injection:
     disable: true
+  artipacked:
+    disable: true


### PR DESCRIPTION
## Summary
- Remove `persist-credentials: false` from release.yml as it breaks `stefanzweifel/git-auto-commit-action@v7` which needs credentials to push
- Add `artipacked` to disabled rules in zizmor.yml to suppress the warning

## Context
The previous zizmor PR added `persist-credentials: false` to all workflow files including release.yml. However, this breaks the release workflow because `git-auto-commit-action` needs credentials to push the changelog update.

## Test plan
- CI passes
- Release workflow will work correctly with credentials preserved

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the release workflow can commit and push during changelog updates; quiets a non-actionable zizmor warning.
> 
> - In `release.yml`, remove `with.persist-credentials: false` from `actions/checkout@v6` so `stefanzweifel/git-auto-commit-action@v7` can push
> - In `zizmor.yml`, disable the `artipacked` rule
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48ed6189eb02a06e8bd739521d67245ce626a260. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->