### PR TITLE
Make prettier more compatible with yamlfix

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,7 +4,7 @@
       "files": ["*.yaml", "*.yml"],
       "options": {
         "singleQuote": true,
-        "printWidth": 100"
+        "printWidth": 100
       }
     }
   ]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Aligns Prettier formatting for YAML with expected line width.
> 
> - Updates `.prettierrc` YAML/YML override to include `printWidth: 100` (keeps `singleQuote: true`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 46de060ddd43346d993835ca963a4b2fa6e94841. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->