### PR TITLE
Use literal block scalar for changelog replace string

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,8 +58,12 @@ jobs:
         uses: jacobtomlinson/gha-find-replace@v3
         with:
           find: "Next\n----"
-          replace: "Next\n----\n\n${{ steps.calver.outputs.release }}\n${{ steps.changelog_underline.outputs.underline\
-            \ }}\n"
+          replace: |
+            Next
+            ----
+
+            ${{ steps.calver.outputs.release }}
+            ${{ steps.changelog_underline.outputs.underline }}
           include: CHANGELOG.rst
           regex: false
 


### PR DESCRIPTION
Use literal block scalar (`|`) with actual newlines instead of escape sequences in the release workflow. This fixes zizmor warnings while being compatible with yamlfix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the release workflow to use a YAML literal block (`|`) for the `replace` value in `Update changelog`, inserting real newlines instead of escaped sequences.
> 
> - Updates `.github/workflows/release.yml` `gha-find-replace` step to a block scalar with `Next`, underline, and interpolated `${{ steps.* }}` values on separate lines
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95a4e4da9d5e13f10b0f59e895bc263e261b9aed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->