### PR TITLE
Add Hypothesis property-based tests for substitution logic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ optional-dependencies.dev = [
     "deptry==0.24.0",
     "doc8==2.0.0",
     "doccmd==2026.3.2",
+    "hypothesis==6.151.9",
     "interrogate==1.7.0",
     "mypy[faster-cache]==1.19.1",
     "mypy-strict-kwargs==2026.1.12",

--- a/tests/test_hypothesis.py
+++ b/tests/test_hypothesis.py
@@ -1,0 +1,280 @@
+"""Property-based tests for substitution logic."""
+
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+from textwrap import dedent
+
+from hypothesis import HealthCheck, assume, given, settings
+from hypothesis.strategies import (
+    booleans,
+    dictionaries,
+    frozensets,
+    just,
+    text,
+    tuples,
+)
+from sphinx.testing.util import SphinxTestApp
+
+from sphinx_substitution_extensions import _apply_substitutions
+
+# Strategy for placeholder names: non-empty text without pipe characters
+# to avoid ambiguous delimiter overlap.
+_placeholder_names = text(
+    alphabet="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-",
+    min_size=1,
+    max_size=20,
+)
+
+# Strategy for replacement values: arbitrary text without pipe characters,
+# so replacements do not introduce new placeholder syntax.
+_safe_replacement_values = text(
+    alphabet="abcdefghijklmnopqrstuvwxyz 0123456789._-/",
+    max_size=50,
+)
+
+_delimiter_pairs = frozensets(
+    tuples(just("|"), just("|")),
+    min_size=1,
+    max_size=1,
+)
+
+_substitution_defs = dictionaries(
+    keys=_placeholder_names,
+    values=_safe_replacement_values,
+    max_size=5,
+)
+
+
+class TestApplySubstitutionsProperties:
+    """Property-based tests for ``_apply_substitutions``."""
+
+    @given(input_text=text(), delimiter_pairs=_delimiter_pairs)
+    def test_empty_substitutions_is_identity(
+        self,
+        *,
+        input_text: str,
+        delimiter_pairs: frozenset[tuple[str, str]],
+    ) -> None:
+        """With no substitution definitions, output equals input."""
+        result = _apply_substitutions(
+            text=input_text,
+            substitution_defs={},
+            delimiter_pairs=set(delimiter_pairs),
+        )
+        assert result == input_text
+
+    @given(
+        name=_placeholder_names,
+        value=_safe_replacement_values,
+    )
+    def test_all_occurrences_replaced(
+        self,
+        *,
+        name: str,
+        value: str,
+    ) -> None:
+        """Every ``|name|`` in the text is replaced with the value."""
+        placeholder = f"|{name}|"
+        input_text = f"before {placeholder} middle {placeholder} after"
+        result = _apply_substitutions(
+            text=input_text,
+            substitution_defs={name: value},
+            delimiter_pairs={("|", "|")},
+        )
+        assert placeholder not in result
+        assert result == f"before {value} middle {value} after"
+
+    @given(
+        input_text=text(
+            alphabet="abcdefghijklmnopqrstuvwxyz 0123456789._-/\n",
+            max_size=100,
+        ),
+        substitution_defs=_substitution_defs,
+    )
+    def test_no_placeholder_in_text_is_identity(
+        self,
+        *,
+        input_text: str,
+        substitution_defs: dict[str, str],
+    ) -> None:
+        """Text without any delimited keys is unchanged."""
+        assume(
+            not any(f"|{name}|" in input_text for name in substitution_defs)
+        )
+
+        result = _apply_substitutions(
+            text=input_text,
+            substitution_defs=substitution_defs,
+            delimiter_pairs={("|", "|")},
+        )
+        assert result == input_text
+
+    @given(
+        name=_placeholder_names,
+        value=_safe_replacement_values,
+    )
+    def test_no_leftover_placeholders(
+        self,
+        *,
+        name: str,
+        value: str,
+    ) -> None:
+        """After substitution, the placeholder pattern is gone.
+
+        This holds when the replacement value does not itself contain
+        the placeholder pattern.
+        """
+        placeholder = f"|{name}|"
+        input_text = f"x {placeholder} y"
+        result = _apply_substitutions(
+            text=input_text,
+            substitution_defs={name: value},
+            delimiter_pairs={("|", "|")},
+        )
+        # The replacement values strategy excludes "|", so the
+        # placeholder cannot reappear.
+        assert placeholder not in result
+
+    @given(
+        name=_placeholder_names,
+        value=_safe_replacement_values,
+    )
+    def test_myst_delimiters(
+        self,
+        *,
+        name: str,
+        value: str,
+    ) -> None:
+        """Substitution works with MyST ``{{ }}`` delimiters."""
+        placeholder = f"{{{{{name}}}}}"
+        input_text = f"pre {placeholder} post"
+        result = _apply_substitutions(
+            text=input_text,
+            substitution_defs={name: value},
+            delimiter_pairs={("{{", "}}")},
+        )
+        assert placeholder not in result
+        assert result == f"pre {value} post"
+
+    @given(
+        name=_placeholder_names,
+        value=_safe_replacement_values,
+    )
+    def test_multiple_delimiter_pairs(
+        self,
+        *,
+        name: str,
+        value: str,
+    ) -> None:
+        """Both RST and MyST delimiters are replaced in one call."""
+        rst_placeholder = f"|{name}|"
+        myst_placeholder = f"{{{{{name}}}}}"
+        input_text = f"{rst_placeholder} and {myst_placeholder}"
+        result = _apply_substitutions(
+            text=input_text,
+            substitution_defs={name: value},
+            delimiter_pairs={("|", "|"), ("{{", "}}")},
+        )
+        assert rst_placeholder not in result
+        assert myst_placeholder not in result
+        assert result == f"{value} and {value}"
+
+
+class TestShouldApplySubstitutionsProperties:
+    """Property-based tests for substitution flag behavior."""
+
+    @settings(
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    @given(default_enabled=booleans())
+    def test_nosubstitutions_flag_prevents_replacement(
+        self,
+        *,
+        default_enabled: bool,
+        make_app: Callable[..., SphinxTestApp],
+    ) -> None:
+        """``:nosubstitutions:`` prevents replacement.
+
+        Regardless of the ``substitutions_default_enabled`` config.
+        """
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            source_directory = Path(tmp_dir) / "source"
+            source_directory.mkdir()
+            source_file = source_directory / "index.rst"
+            (source_directory / "conf.py").touch()
+
+            source_file_content = dedent(
+                text="""\
+                .. |a| replace:: example_substitution
+
+                .. code-block:: shell
+                   :nosubstitutions:
+
+                   $ PRE-|a|-POST
+                """,
+            )
+            source_file.write_text(data=source_file_content)
+            app = make_app(
+                srcdir=source_directory,
+                exception_on_warning=True,
+                confoverrides={
+                    "extensions": ["sphinx_substitution_extensions"],
+                    "substitutions_default_enabled": default_enabled,
+                },
+            )
+            app.build()
+            assert app.statuscode == 0
+            content_html = (app.outdir / "index.html").read_text()
+            app.cleanup()
+
+            # The substitution value should NOT appear.
+            assert "example_substitution" not in content_html
+
+    @settings(
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    @given(default_enabled=booleans())
+    def test_substitutions_flag_forces_replacement(
+        self,
+        *,
+        default_enabled: bool,
+        make_app: Callable[..., SphinxTestApp],
+    ) -> None:
+        """``:substitutions:`` forces replacement.
+
+        Regardless of the ``substitutions_default_enabled`` config.
+        """
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            source_directory = Path(tmp_dir) / "source"
+            source_directory.mkdir()
+            source_file = source_directory / "index.rst"
+            (source_directory / "conf.py").touch()
+
+            source_file_content = dedent(
+                text="""\
+                .. |a| replace:: example_substitution
+
+                .. code-block:: shell
+                   :substitutions:
+
+                   $ PRE-|a|-POST
+                """,
+            )
+            source_file.write_text(data=source_file_content)
+            app = make_app(
+                srcdir=source_directory,
+                exception_on_warning=True,
+                confoverrides={
+                    "extensions": ["sphinx_substitution_extensions"],
+                    "substitutions_default_enabled": default_enabled,
+                },
+            )
+            app.build()
+            assert app.statuscode == 0
+            content_html = (app.outdir / "index.html").read_text()
+            app.cleanup()
+
+            # The placeholder SHOULD be replaced.
+            assert "PRE-example_substitution-POST" in content_html
+            assert "PRE-|a|-POST" not in content_html

--- a/tests/test_hypothesis.py
+++ b/tests/test_hypothesis.py
@@ -16,7 +16,9 @@ from hypothesis.strategies import (
 )
 from sphinx.testing.util import SphinxTestApp
 
-from sphinx_substitution_extensions import _apply_substitutions
+from sphinx_substitution_extensions import (
+    _apply_substitutions,  # pyright: ignore[reportPrivateUsage]
+)
 
 # Strategy for placeholder names: non-empty text without pipe characters
 # to avoid ambiguous delimiter overlap.

--- a/tests/test_hypothesis.py
+++ b/tests/test_hypothesis.py
@@ -34,7 +34,7 @@ _safe_replacement_values = text(
 )
 
 _delimiter_pairs = frozensets(
-    tuples(just("|"), just("|")),
+    elements=tuples(just(value="|"), just(value="|")),
     min_size=1,
     max_size=1,
 )
@@ -100,7 +100,9 @@ class TestApplySubstitutionsProperties:
     ) -> None:
         """Text without any delimited keys is unchanged."""
         assume(
-            not any(f"|{name}|" in input_text for name in substitution_defs)
+            condition=not any(
+                f"|{name}|" in input_text for name in substitution_defs
+            ),
         )
 
         result = _apply_substitutions(


### PR DESCRIPTION
## Summary
- Add `hypothesis` dependency for property-based testing
- Add 8 property-based tests covering `_apply_substitutions` and flag behavior:
  - Empty substitutions is identity
  - All placeholder occurrences are replaced
  - Text without placeholders is unchanged
  - No leftover placeholders after substitution
  - MyST `{{ }}` delimiters work correctly
  - Multiple delimiter pairs work in one call
  - `:nosubstitutions:` prevents replacement regardless of config
  - `:substitutions:` forces replacement regardless of config

## Test plan
- [x] All 47 tests pass (8 new + 39 existing)
- [x] 100% code coverage maintained
- [x] All pre-commit hooks pass (mypy, pyright, ruff, interrogate, etc.)

Closes #1423

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds a dev-only testing dependency and new property-based tests; no runtime code or substitution logic is modified.
> 
> **Overview**
> Adds `hypothesis` to the dev dependency set and introduces a new `tests/test_hypothesis.py` suite of property-based tests.
> 
> The new tests stress `_apply_substitutions` across randomized inputs (identity cases, full replacement, MyST `{{ }}` support, and mixed delimiter pairs) and verify `:nosubstitutions:`/`:substitutions:` flags override `substitutions_default_enabled` when building a minimal Sphinx project.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5821c2c028fa83885b38a96ff5f4202c64596e4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->