### PR TITLE
Use pytest-beartype-tests plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ optional-dependencies.dev = [
     "pyright==1.1.408",
     "pyroma==5.0.1",
     "pytest==9.0.3",
+    "pytest-beartype-tests",
     "pytest-cov==7.1.0",
     "ruff==0.15.11",
     # We add shellcheck-py not only for shell scripts and shell code blocks,
@@ -78,6 +79,9 @@ optional-dependencies.dev = [
 optional-dependencies.release = [ "check-wheel-contents==0.6.3" ]
 urls.Source = "https://github.com/adamtheturtle/sphinx-substitution-extensions"
 
+[dependency-groups]
+dev = []
+
 [tool.setuptools]
 zip-safe = false
 package-data.sphinx_substitution_extensions = [
@@ -97,6 +101,9 @@ bdist_wheel.universal = true
 #
 # Code to match this is in ``conf.py``.
 version_scheme = "post-release"
+
+[tool.uv]
+sources.pytest-beartype-tests = { git = "https://github.com/adamtheturtle/pytest-beartype-tests.git", rev = "bc81d99" }
 
 [tool.ruff]
 line-length = 79
@@ -323,7 +330,6 @@ ignore_path = [
 ignore_names = [
     # pytest configuration
     "pytest_collect_file",
-    "pytest_collection_modifyitems",
     "pytest_plugins",
     # pytest fixtures - we name fixtures like this for this purpose
     "fixture_*",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,3 @@
 """Configuration for pytest."""
 
-import pytest
-from beartype import beartype
-
 pytest_plugins = "sphinx.testing.fixtures"  # pylint: disable=invalid-name
-
-
-def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
-    """Apply the beartype decorator to all collected test functions."""
-    for item in items:
-        # All our tests are functions, for now
-        assert isinstance(item, pytest.Function)
-        item.obj = beartype(obj=item.obj)


### PR DESCRIPTION
This PR adds the [`pytest-beartype-tests`](https://github.com/adamtheturtle/pytest-beartype-tests) dev dependency and removes redundant `pytest_collection_modifyitems` wiring from conftest where it duplicated the plugin.

The dependency is pinned to [git `bc81d99`](https://github.com/adamtheturtle/pytest-beartype-tests/commit/bc81d99) via `[tool.uv.sources]` until a PyPI release includes the Sybil-safe plugin fix.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes test tooling by replacing a local `pytest_collection_modifyitems` hook with an external plugin, plus minor `pyproject.toml` config updates.
> 
> **Overview**
> Test runtime type-checking is now provided via the `pytest-beartype-tests` plugin instead of a custom `pytest_collection_modifyitems` hook in `tests/conftest.py`.
> 
> The PR adds `pytest-beartype-tests` to dev dependencies, pins it via `uv` to a specific git revision, and updates `pyproject.toml` config (including dropping `pytest_collection_modifyitems` from `vulture` ignore names and adding an empty `[dependency-groups]`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea95496ca9effe1f84fee701403555eb98df32d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->