### PR TITLE
Pin pytest-beartype-tests to 2026.4.20 on PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,8 +102,6 @@ bdist_wheel.universal = true
 # Code to match this is in ``conf.py``.
 version_scheme = "post-release"
 
-[tool.uv]
-
 [tool.ruff]
 line-length = 79
 lint.select = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ optional-dependencies.dev = [
     "pyright==1.1.408",
     "pyroma==5.0.1",
     "pytest==9.0.3",
-    "pytest-beartype-tests",
+    "pytest-beartype-tests==2026.4.20",
     "pytest-cov==7.1.0",
     "ruff==0.15.11",
     # We add shellcheck-py not only for shell scripts and shell code blocks,
@@ -103,7 +103,6 @@ bdist_wheel.universal = true
 version_scheme = "post-release"
 
 [tool.uv]
-sources.pytest-beartype-tests = { git = "https://github.com/adamtheturtle/pytest-beartype-tests.git", rev = "bc81d99" }
 
 [tool.ruff]
 line-length = 79


### PR DESCRIPTION
Replace the temporary `[tool.uv.sources]` git pin to bc81d99 with the published PyPI release `pytest-beartype-tests==2026.4.20` (same Sybil-safe plugin behavior).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency pinning/config-only change that does not alter runtime code paths; risk is limited to potential differences between the prior git revision and the released package.
> 
> **Overview**
> Updates the dev dependency on `pytest-beartype-tests` to a pinned PyPI version (`==2026.4.20`) instead of relying on an unpinned/implicit install.
> 
> Removes the `[tool.uv]` git `sources.pytest-beartype-tests` override, simplifying dependency resolution to use the published package release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e22ed87a804ce19cafeefcbc4db2f6f8a1d6a0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->