### PR TITLE
Use sphinx-toolbox 4.2.0rc1 and Sphinx 9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,11 +65,9 @@ optional-dependencies.dev = [
     # use it to lint shell commands in GitHub workflow files.
     "shellcheck-py==0.11.0.1",
     "shfmt-py==3.12.0.2",
-    # Pin Sphinx <9 for sphinx_toolbox compatibility in sample project.
-    # See https://github.com/sphinx-toolbox/sphinx-toolbox/issues/201
-    "sphinx>=8.1.0,<9",
+    "sphinx>=9,<10",
     "sphinx-lint==1.0.2",
-    "sphinx-toolbox==4.1.2",
+    "sphinx-toolbox==4.2.0rc1",
     "ty==0.0.33",
     "types-docutils==0.22.3.20260408",
     "vulture==2.16",


### PR DESCRIPTION
## Summary
- bump dev `sphinx-toolbox` to `4.2.0rc1`
- update dev Sphinx constraint to `>=9,<10`
- remove outdated comment about Sphinx `<9`

## Test plan
- [x] dependency constraints updated in `pyproject.toml`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since this only adjusts dev dependency constraints, but using a `rc` release could introduce doc-build or linting regressions in CI.
> 
> **Overview**
> Updates `pyproject.toml` dev dependencies to require **Sphinx `>=9,<10`** and bumps **`sphinx-toolbox` to `4.2.0rc1`**, removing the old Sphinx `<9` compatibility pin/comment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a140b14c4a7c8d2033bebf1a58f703678f33be6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->