### PR TITLE
Bump mypy to 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ optional-dependencies.dev = [
     "doc8==2.0.0",
     "doccmd==2026.3.26.2",
     "interrogate==1.7.0",
-    "mypy[faster-cache]==1.20.2",
+    "mypy[faster-cache]==2.0.0",
     "mypy-strict-kwargs==2026.1.12",
     "prek==0.3.12",
     "pydocstringformatter==0.7.5",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this only updates a dev-only type-checking dependency and does not change runtime code paths.
> 
> **Overview**
> Updates the dev dependency pin for `mypy[faster-cache]` from `1.20.2` to `2.0.0` in `pyproject.toml`, aligning local/CI type-checking with the new mypy major version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d897316e6016d99f18d5cc64ab2953ee871ec4b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->