### PR TITLE
Enable mypy parallel workers in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -153,7 +153,7 @@ repos:
       - id: mypy
         name: mypy
         stages: [pre-push]
-        entry: uv run --extra=dev -m mypy -j 4
+        entry: uv run --extra=dev -m mypy --num-workers=4
         language: python
         types_or: [python, toml]
         pass_filenames: false
@@ -165,7 +165,7 @@ repos:
         name: mypy-docs
         stages: [pre-push]
         entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy
-          -j 4"
+          --num-workers=4"
         language: python
         types_or: [markdown, rst]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -153,7 +153,7 @@ repos:
       - id: mypy
         name: mypy
         stages: [pre-push]
-        entry: uv run --extra=dev -m mypy
+        entry: uv run --extra=dev -m mypy -j 4
         language: python
         types_or: [python, toml]
         pass_filenames: false
@@ -164,7 +164,8 @@ repos:
       - id: mypy-docs
         name: mypy-docs
         stages: [pre-push]
-        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy"
+        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy
+          -j 4"
         language: python
         types_or: [markdown, rst]
 


### PR DESCRIPTION
## Summary
- configure the `mypy` pre-push hook to run with 4 parallel workers via `-j 4`
- update the `mypy-docs` `doccmd` command string to also run `mypy -j 4`

## Test plan
- [x] run pre-commit hooks during commit
- [x] verify `.pre-commit-config.yaml` includes worker settings for both hooks

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts pre-push hook commands to enable mypy parallelism; no runtime or production code paths change.
> 
> **Overview**
> Speeds up local type-checking by updating the pre-push `mypy` hook to run with `--num-workers=4`.
> 
> Updates the `mypy-docs` `doccmd` invocation to pass the same worker setting when validating docs code blocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bde394df25767bdc4b56251812402dce3acb73ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->