### PR TITLE
Add strict-kwargs pre-commit hook in fix mode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -314,7 +314,6 @@ repos:
           - *uv_version
         stages: [pre-commit]
 
-
       - id: strict-kwargs-fix
         name: strict-kwargs
         entry: uv run --extra=dev strict-kwargs fix

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ ci:
   skip:
     - actionlint
     - sphinx-lint
+    - strict-kwargs-fix
     - check-manifest
     - deptry
     - doc8
@@ -312,6 +313,17 @@ repos:
         additional_dependencies:
           - *uv_version
         stages: [pre-commit]
+
+
+      - id: strict-kwargs-fix
+        name: strict-kwargs
+        entry: uv run --extra=dev strict-kwargs fix
+        language: python
+        types_or: [python]
+        additional_dependencies:
+          - *uv_version
+        stages: [pre-commit]
+        require_serial: true
 
       - id: doc8
         name: doc8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ optional-dependencies.dev = [
     "sphinx>=9,<10",
     "sphinx-lint==1.0.2",
     "sphinx-toolbox==4.2.0rc1",
-    "strict-kwargs==2026.5.18",
+    "strict-kwargs==2026.5.18.post1",
     "ty==0.0.36",
     "types-docutils==0.22.3.20260508",
     "vulture==2.16",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ optional-dependencies.dev = [
     "vulture==2.16",
     "yamlfix==1.19.1",
     "zizmor==1.25.0",
+
 ]
 optional-dependencies.release = [ "check-wheel-contents==0.6.3" ]
 urls.Source = "https://github.com/adamtheturtle/sphinx-substitution-extensions"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,6 @@ optional-dependencies.dev = [
     "vulture==2.16",
     "yamlfix==1.19.1",
     "zizmor==1.25.0",
-
 ]
 optional-dependencies.release = [ "check-wheel-contents==0.6.3" ]
 urls.Source = "https://github.com/adamtheturtle/sphinx-substitution-extensions"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,7 @@ dependencies = [
     "myst-parser>=4.0.0",
     "sphinx>=8.1.0",
 ]
-optional-dependencies.dev = [
-    "actionlint-py==1.7.12.24",
+optional-dependencies.dev = [    "actionlint-py==1.7.12.24",
     "check-manifest==0.51",
     "deptry==0.25.1",
     "doc8==2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ optional-dependencies.dev = [
     "sphinx>=9,<10",
     "sphinx-lint==1.0.2",
     "sphinx-toolbox==4.2.0rc1",
+    "strict-kwargs==2026.5.18",
     "ty==0.0.36",
     "types-docutils==0.22.3.20260508",
     "vulture==2.16",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,8 @@ dependencies = [
     "myst-parser>=4.0.0",
     "sphinx>=8.1.0",
 ]
-optional-dependencies.dev = [    "actionlint-py==1.7.12.24",
+optional-dependencies.dev = [
+    "actionlint-py==1.7.12.24",
     "check-manifest==0.51",
     "deptry==0.25.1",
     "doc8==2.0.0",


### PR DESCRIPTION
## Summary
- Add the [strict-kwargs](https://github.com/adamtheturtle/strict-kwargs) pre-commit hook (`rev: 2026.5.18`) with `args: [fix]` so positional call arguments are rewritten to keyword form on commit.
- Skip the hook in pre-commit CI (builds from source and needs a Rust toolchain).
- Mirror `[tool.mypy_strict_kwargs]` into `[tool.strict_kwargs]` where custom ignore lists already exist.

## Test plan
- [ ] `pre-commit run strict-kwargs --all-files`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since changes are limited to developer tooling (pre-commit) and dev dependencies, with no runtime/library behavior modifications; main impact is potential automatic code rewrites during commits.
> 
> **Overview**
> Adds a new local pre-commit hook, `strict-kwargs-fix`, which runs `strict-kwargs fix` (serially) on Python files to rewrite positional call arguments into keyword form.
> 
> Updates pre-commit CI configuration to skip this hook, and adds `strict-kwargs` to the `dev` optional dependencies in `pyproject.toml` so the hook can be executed via `uv run`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc794658df1140b2a376810ffe529d7c4c421497. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->