### PR TITLE
[codex] Add towncrier to release extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ optional-dependencies.dev = [
     "yamlfix==1.19.1",
     "zizmor==1.25.2",
 ]
-optional-dependencies.release = [ "check-wheel-contents==0.6.3" ]
+optional-dependencies.release = [ "check-wheel-contents==0.6.3", "towncrier==25.8.0" ]
 urls.Source = "https://github.com/adamtheturtle/sphinx-substitution-extensions"
 
 [dependency-groups]


### PR DESCRIPTION
## Summary

Add `towncrier==25.8.0` to the `release` extra so the release workflow can run:

```bash
uv run --extra=release towncrier build ...
```

The previous towncrier migration added the tool for development/docs builds, but release jobs install only the `release` extra before invoking towncrier.

## Validation

- `uv lock`
- `uv run --no-dev --extra=release towncrier --version`
- repo pre-commit / pre-push hooks run by `git commit` and `git push`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only change that affects release tooling installation; primary risk is minor CI/release environment dependency resolution changes.
> 
> **Overview**
> Adds `towncrier==25.8.0` to the `release` optional dependency extra in `pyproject.toml`, ensuring release workflows that install only `--extra=release` have `towncrier` available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af5487b5c85c28cfae3df7095a41c5ad2f5d4b4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->