### PR TITLE
[codex] Make useless Pylint suppressions fail lint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,6 +172,10 @@ MASTER.load-plugins = [
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
 MASTER.unsafe-load-any-extension = false
+# Return non-zero exit code if useless-suppression is emitted.
+MAIN.fail-on = [
+    "useless-suppression",
+]
 DEPRECATED_BUILTINS.bad-functions = [
     # Use Pylint until Ruff can ban bare builtin calls, or until custom rules
     # make this removable:


### PR DESCRIPTION
## Summary

- Configure Pylint to fail when `useless-suppression` is emitted.
- Keep existing useless-suppression enablement and project-specific Pylint settings intact.

## Validation

- Parsed `pyproject.toml` with `tomllib`.
- Ran `pylint --rcfile pyproject.toml --list-msgs-enabled`.
- Ran repository commit hooks for the changed file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change; it may cause CI/lint failures in repos with stale `# pylint: disable` pragmas but does not affect runtime behavior.
> 
> **Overview**
> Makes linting stricter by configuring Pylint to **exit non-zero when it emits `useless-suppression`** via `MAIN.fail-on` in `pyproject.toml`.
> 
> This turns unused/obsolete Pylint suppression comments into hard failures, while leaving the existing `useless-suppression` message enabled and other Pylint settings unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0041d9afdb8abf721d6fea7e1ec0505e60e5892a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->