### PR TITLE
feat: add support for nested substitutions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -233,7 +233,7 @@ Replace substitutions in the image path:
    ```
 
 Nested substitutions
-~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
 
 ``myst_substitutions`` supports nested dictionaries and lists, which are flattened using dot notation.
 

--- a/README.rst
+++ b/README.rst
@@ -237,6 +237,8 @@ Nested substitutions
 
 ``myst_substitutions`` supports nested dictionaries and lists, which are flattened using dot notation.
 
+**Important:** Substitution keys cannot contain dots (``.``), as dots are reserved for nested access notation. For example, ``{"key.with.dots": "value"}`` is not allowed, but ``{"key": {"with": {"dots": "value"}}}`` is valid and accessed as ``|key.with.dots|``.
+
 Nested dictionaries:
 
 .. code-block:: python

--- a/README.rst
+++ b/README.rst
@@ -232,6 +232,107 @@ Replace substitutions in the image path:
       :alt: Diagram
    ```
 
+Nested substitutions
+~~~~~~~~~~~~~~~~~~~~
+
+``myst_substitutions`` supports nested dictionaries and lists, which are flattened using dot notation.
+
+Nested dictionaries:
+
+.. code-block:: python
+
+   """Configuration for Sphinx."""
+
+   myst_substitutions = {
+       "app": {
+           "name": "MyApp",
+           "version": "1.0.0",
+       },
+   }
+
+Usage in Markdown:
+
+.. code-block:: markdown
+
+   ```{code-block} bash
+      :substitutions:
+
+      echo "Application: |app.name| version |app.version|"
+   ```
+
+Lists with index access:
+
+.. code-block:: python
+
+   """Configuration for Sphinx."""
+
+   myst_substitutions = {
+       "platforms": ["Linux", "Windows", "macOS"],
+   }
+
+Usage:
+
+.. code-block:: markdown
+
+   ```{code-block} bash
+      :substitutions:
+
+      echo "First platform: |platforms.0|"
+      echo "Second platform: |platforms.1|"
+   ```
+
+Nested lists of dictionaries:
+
+.. code-block:: python
+
+   """Configuration for Sphinx."""
+
+   myst_substitutions = {
+       "releases": [
+           {"version": "1.0", "codename": "Alpha"},
+           {"version": "2.0", "codename": "Beta"},
+       ],
+   }
+
+Usage:
+
+.. code-block:: markdown
+
+   ```{code-block} bash
+      :substitutions:
+
+      echo "First release: |releases.0.version| (|releases.0.codename|)"
+      echo "Second release: |releases.1.version| (|releases.1.codename|)"
+   ```
+
+Complex nested structures:
+
+.. code-block:: python
+
+   """Configuration for Sphinx."""
+
+   myst_substitutions = {
+       "project": {
+           "name": "MyProject",
+           "contributors": [
+               {"name": "Alice", "role": "dev"},
+               {"name": "Bob", "role": "docs"},
+           ],
+       },
+   }
+
+Usage:
+
+.. code-block:: markdown
+
+   ```{code-block} bash
+      :substitutions:
+
+      echo "Project: |project.name|"
+      echo "Developer: |project.contributors.0.name|"
+      echo "Documentation: |project.contributors.1.name|"
+   ```
+
 Credits
 -------
 

--- a/README.rst
+++ b/README.rst
@@ -237,7 +237,8 @@ Nested substitutions
 
 ``myst_substitutions`` supports nested dictionaries and lists, which are flattened using dot notation.
 
-**Important:** Substitution keys cannot contain dots (``.``), as dots are reserved for nested access notation. For example, ``{"key.with.dots": "value"}`` is not allowed, but ``{"key": {"with": {"dots": "value"}}}`` is valid and accessed as ``|key.with.dots|``.
+**Important:** Substitution keys cannot contain dots (``.``), as dots are reserved for nested access notation.
+For example, ``{"key.with.dots": "value"}`` raises an exception.
 
 Nested dictionaries:
 

--- a/src/sphinx_substitution_extensions/__init__.py
+++ b/src/sphinx_substitution_extensions/__init__.py
@@ -1,7 +1,7 @@
 """Custom Sphinx extensions."""
 
 from importlib.metadata import version
-from typing import Any, ClassVar
+from typing import Any, ClassVar, TypeAlias
 
 from beartype import beartype
 from docutils.nodes import (
@@ -33,6 +33,34 @@ from sphinx_substitution_extensions.shared import (
     PATH_SUBSTITUTION_OPTION_NAME,
     SUBSTITUTION_OPTION_NAME,
 )
+
+SubstitutionValue: TypeAlias = str | dict[str, "SubstitutionValue"]
+Substitutions: TypeAlias = dict[str, SubstitutionValue]
+
+
+@beartype
+def _flatten_substitutions(
+    substitutions: Substitutions,
+    prefix: str = "",
+) -> dict[str, str]:
+    """Flatten nested substitutions dictionary.
+
+    Example:
+        {'a': {'b': {'c': 'value'}}} -> {'a.b.c': 'value'}
+    """
+    result: dict[str, str] = {}
+    stack: list[tuple[str, Substitutions]] = [(prefix, substitutions)]
+
+    while stack:
+        current_prefix, current_dict = stack.pop()
+        for key, value in current_dict.items():
+            new_key = f"{current_prefix}.{key}" if current_prefix else key
+            if isinstance(value, dict):
+                stack.append((new_key, value))
+            else:
+                result[new_key] = value
+
+    return result
 
 
 @beartype
@@ -81,7 +109,9 @@ def _get_substitution_defs(
     parser_supported_formats = set(env.parser.supported)
     if parser_supported_formats.intersection(markdown_suffixes):
         if "substitution" in config.myst_enable_extensions:
-            return dict(config.myst_substitutions)
+            return _flatten_substitutions(
+                substitutions=dict(config.myst_substitutions),
+            )
     else:
         return {
             key: value.astext() for key, value in substitution_defs.items()

--- a/src/sphinx_substitution_extensions/__init__.py
+++ b/src/sphinx_substitution_extensions/__init__.py
@@ -61,18 +61,21 @@ def _flatten_substitutions(
     while stack:
         current_key, current_value = stack.pop()
 
-        if isinstance(current_value, dict):
-            for key, value in current_value.items():
-                new_key = f"{current_key}.{key}" if current_key else key
-                stack.append((new_key, value))
-        elif isinstance(current_value, list):
-            for idx, item in enumerate(iterable=current_value):
-                new_key = (
-                    f"{current_key}.{idx}" if current_key else str(object=idx)
-                )
-                stack.append((new_key, item))
-        else:
-            result[current_key] = str(object=current_value)
+        match current_value:
+            case dict():
+                for key, value in current_value.items():
+                    new_key = f"{current_key}.{key}" if current_key else key
+                    stack.append((new_key, value))
+            case list():
+                for idx, item in enumerate(iterable=current_value):
+                    new_key = (
+                        f"{current_key}.{idx}"
+                        if current_key
+                        else str(object=idx)
+                    )
+                    stack.append((new_key, item))
+            case _:
+                result[current_key] = str(object=current_value)
 
     return result
 

--- a/src/sphinx_substitution_extensions/__init__.py
+++ b/src/sphinx_substitution_extensions/__init__.py
@@ -66,11 +66,13 @@ def _flatten_substitutions(
                 new_key = f"{current_key}.{key}" if current_key else key
                 stack.append((new_key, value))
         elif isinstance(current_value, list):
-            for idx, item in enumerate(current_value):  # type: ignore[misc]
-                new_key = f"{current_key}.{idx}" if current_key else str(idx)  # type: ignore[call-overload]
+            for idx, item in enumerate(iterable=current_value):
+                new_key = (
+                    f"{current_key}.{idx}" if current_key else str(object=idx)
+                )
                 stack.append((new_key, item))
         else:
-            result[current_key] = str(current_value)  # type: ignore[call-overload]
+            result[current_key] = str(object=current_value)
 
     return result
 

--- a/src/sphinx_substitution_extensions/__init__.py
+++ b/src/sphinx_substitution_extensions/__init__.py
@@ -54,11 +54,7 @@ def _validate_substitution_key(*, key: str) -> None:
     Allowing dots in user-defined keys would create ambiguity between
     a literal key name and a path to a nested value.
 
-    Args:
-        key: The substitution key to validate.
-
-    Raises:
-        SphinxError: If the key contains a dot.
+    A :class:`~sphinx.errors.SphinxError` is raised if the key contains a dot.
     """
     if "." in key:
         message = (
@@ -80,33 +76,13 @@ def _flatten_substitutions(
 
     Recursively processes nested dictionaries and lists, converting them
     to a flat dictionary where keys represent the path to each value using
-    dot notation.
+    dot notation. For example::
 
-    Examples:
-        Nested dictionaries::
+        {'a': {'b': {'c': 'value'}}} -> {'a.b.c': 'value'}
+        {'items': [{'name': 'a'}]} -> {'items.0.name': 'a'}
 
-            {'a': {'b': {'c': 'value'}}} -> {'a.b.c': 'value'}
-
-        Lists with index access::
-
-            {'items': [{'name': 'a'}]} -> {'items.0.name': 'a'}
-
-        Mixed structures::
-
-            {
-                'app': {'version': '1.0'},
-                'contributors': [{'name': 'Alice'}]
-            }
-            -> {'app.version': '1.0', 'contributors.0.name': 'Alice'}
-
-    Args:
-        substitutions: The nested substitutions dictionary to flatten.
-
-    Returns:
-        A flat dictionary mapping dot-notation keys to string values.
-
-    Raises:
-        SphinxError: If any key in the nested structure contains a dot.
+    A :class:`~sphinx.errors.SphinxError` is raised if any key in the nested
+    structure contains a dot.
     """
     result: dict[str, str] = {}
     stack: list[tuple[str, SubstitutionValue]] = [("", substitutions)]

--- a/src/sphinx_substitution_extensions/__init__.py
+++ b/src/sphinx_substitution_extensions/__init__.py
@@ -34,11 +34,16 @@ from sphinx_substitution_extensions.shared import (
     SUBSTITUTION_OPTION_NAME,
 )
 
-SubstitutionValue: TypeAlias = str | dict[str, "SubstitutionValue"]
+SubstitutionValue: TypeAlias = (
+    str
+    | int
+    | float
+    | list["SubstitutionValue"]
+    | dict[str, "SubstitutionValue"]
+)
 Substitutions: TypeAlias = dict[str, SubstitutionValue]
 
 
-@beartype
 def _flatten_substitutions(
     substitutions: Substitutions,
     prefix: str = "",
@@ -47,18 +52,24 @@ def _flatten_substitutions(
 
     Example:
         {'a': {'b': {'c': 'value'}}} -> {'a.b.c': 'value'}
+        {'items': [{'name': 'a'}]} -> {'items.0.name': 'a'}
     """
     result: dict[str, str] = {}
-    stack: list[tuple[str, Substitutions]] = [(prefix, substitutions)]
+    stack: list[tuple[str, SubstitutionValue]] = [(prefix, substitutions)]
 
     while stack:
-        current_prefix, current_dict = stack.pop()
-        for key, value in current_dict.items():
-            new_key = f"{current_prefix}.{key}" if current_prefix else key
-            if isinstance(value, dict):
+        current_key, current_value = stack.pop()
+
+        if isinstance(current_value, dict):
+            for key, value in current_value.items():
+                new_key = f"{current_key}.{key}" if current_key else key
                 stack.append((new_key, value))
-            else:
-                result[new_key] = value
+        elif isinstance(current_value, list):
+            for idx, item in enumerate(current_value):  # type: ignore[misc]
+                new_key = f"{current_key}.{idx}" if current_key else str(idx)  # type: ignore[call-overload]
+                stack.append((new_key, item))
+        else:
+            result[current_key] = str(current_value)  # type: ignore[call-overload]
 
     return result
 

--- a/src/sphinx_substitution_extensions/__init__.py
+++ b/src/sphinx_substitution_extensions/__init__.py
@@ -50,7 +50,6 @@ Substitutions: TypeAlias = dict[str, SubstitutionValue]
 def _flatten_substitutions(
     *,
     substitutions: Substitutions,
-    prefix: str,
 ) -> dict[str, str]:
     """Flatten nested substitutions dictionary.
 
@@ -59,7 +58,7 @@ def _flatten_substitutions(
         {'items': [{'name': 'a'}]} -> {'items.0.name': 'a'}
     """
     result: dict[str, str] = {}
-    stack: list[tuple[str, SubstitutionValue]] = [(prefix, substitutions)]
+    stack: list[tuple[str, SubstitutionValue]] = [("", substitutions)]
 
     while stack:
         current_key, current_value = stack.pop()
@@ -131,7 +130,6 @@ def _get_substitution_defs(
         if "substitution" in config.myst_enable_extensions:
             return _flatten_substitutions(
                 substitutions=dict(config.myst_substitutions),
-                prefix="",
             )
     else:
         return {

--- a/src/sphinx_substitution_extensions/__init__.py
+++ b/src/sphinx_substitution_extensions/__init__.py
@@ -22,6 +22,7 @@ from sphinx.application import Sphinx
 from sphinx.config import Config
 from sphinx.directives.code import CodeBlock, LiteralInclude
 from sphinx.environment import BuildEnvironment
+from sphinx.errors import SphinxError
 from sphinx.roles import XRefRole
 from sphinx.util.typing import ExtensionMetadata, OptionSpec
 
@@ -44,6 +45,30 @@ SubstitutionValue: TypeAlias = (
 Substitutions: TypeAlias = dict[str, SubstitutionValue]
 
 
+@beartype
+def _validate_substitution_key(*, key: str) -> None:
+    """Validate that a substitution key does not contain dots.
+
+    Dots are reserved for nested access notation in flattened keys
+    (e.g., |a.b.c| for nested dictionaries or |items.0| for lists).
+    Allowing dots in user-defined keys would create ambiguity between
+    a literal key name and a path to a nested value.
+
+    Args:
+        key: The substitution key to validate.
+
+    Raises:
+        SphinxError: If the key contains a dot.
+    """
+    if "." in key:
+        message = (
+            f"Substitution key {key!r} contains a dot ('.'). "
+            "Dots are reserved for nested access notation "
+            "(e.g., |a.b.c| for nested dictionaries or |items.0| for lists)."
+        )
+        raise SphinxError(message)
+
+
 # NOTE: beartype is not used here
 # because it throws `beartype.roar.BeartypeCallHintForwardRefException`
 # for recursive type `Substitutions`
@@ -51,11 +76,37 @@ def _flatten_substitutions(
     *,
     substitutions: Substitutions,
 ) -> dict[str, str]:
-    """Flatten nested substitutions dictionary.
+    """Flatten nested substitutions dictionary using dot notation.
 
-    Example:
-        {'a': {'b': {'c': 'value'}}} -> {'a.b.c': 'value'}
-        {'items': [{'name': 'a'}]} -> {'items.0.name': 'a'}
+    Recursively processes nested dictionaries and lists, converting them
+    to a flat dictionary where keys represent the path to each value using
+    dot notation.
+
+    Examples:
+        Nested dictionaries::
+
+            {'a': {'b': {'c': 'value'}}} -> {'a.b.c': 'value'}
+
+        Lists with index access::
+
+            {'items': [{'name': 'a'}]} -> {'items.0.name': 'a'}
+
+        Mixed structures::
+
+            {
+                'app': {'version': '1.0'},
+                'contributors': [{'name': 'Alice'}]
+            }
+            -> {'app.version': '1.0', 'contributors.0.name': 'Alice'}
+
+    Args:
+        substitutions: The nested substitutions dictionary to flatten.
+
+    Returns:
+        A flat dictionary mapping dot-notation keys to string values.
+
+    Raises:
+        SphinxError: If any key in the nested structure contains a dot.
     """
     result: dict[str, str] = {}
     stack: list[tuple[str, SubstitutionValue]] = [("", substitutions)]
@@ -66,6 +117,7 @@ def _flatten_substitutions(
         match current_value:
             case dict():
                 for key, value in current_value.items():
+                    _validate_substitution_key(key=key)
                     new_key = f"{current_key}.{key}" if current_key else key
                     stack.append((new_key, value))
             case list():

--- a/src/sphinx_substitution_extensions/__init__.py
+++ b/src/sphinx_substitution_extensions/__init__.py
@@ -45,8 +45,9 @@ Substitutions: TypeAlias = dict[str, SubstitutionValue]
 
 
 def _flatten_substitutions(
+    *,
     substitutions: Substitutions,
-    prefix: str = "",
+    prefix: str,
 ) -> dict[str, str]:
     """Flatten nested substitutions dictionary.
 
@@ -122,6 +123,7 @@ def _get_substitution_defs(
         if "substitution" in config.myst_enable_extensions:
             return _flatten_substitutions(
                 substitutions=dict(config.myst_substitutions),
+                prefix="",
             )
     else:
         return {

--- a/src/sphinx_substitution_extensions/__init__.py
+++ b/src/sphinx_substitution_extensions/__init__.py
@@ -44,6 +44,9 @@ SubstitutionValue: TypeAlias = (
 Substitutions: TypeAlias = dict[str, SubstitutionValue]
 
 
+# NOTE: beartype is not used here
+# because it throws `beartype.roar.BeartypeCallHintForwardRefException`
+# for recursive type `Substitutions`
 def _flatten_substitutions(
     *,
     substitutions: Substitutions,

--- a/tests/test_substitution_extensions.py
+++ b/tests/test_substitution_extensions.py
@@ -1702,7 +1702,7 @@ class TestMyst:
         tmp_path: Path,
         make_app: Callable[..., SphinxTestApp],
     ) -> None:
-        """MyST empty containers (lists and dicts) do not create keys
+        """MyST empty containers (lists and dictionaries) do not create keys
         and do not break the build.
         """
         source_directory = tmp_path / "source"

--- a/tests/test_substitution_extensions.py
+++ b/tests/test_substitution_extensions.py
@@ -5,6 +5,8 @@ from importlib.metadata import version
 from pathlib import Path
 from textwrap import dedent
 
+import pytest
+from sphinx.errors import SphinxError
 from sphinx.testing.util import SphinxTestApp
 
 import sphinx_substitution_extensions
@@ -2094,6 +2096,122 @@ class TestMyst:
         ]
         for text in expected_text_in_html:
             assert text in content_html
+
+    @staticmethod
+    def test_myst_substitution_key_with_dot_raises_error(
+        *,
+        tmp_path: Path,
+        make_app: Callable[..., SphinxTestApp],
+    ) -> None:
+        """MyST substitution keys containing dots raise SphinxError.
+
+        Dots are reserved for nested access notation.
+        """
+        source_directory = tmp_path / "source"
+        source_directory.mkdir()
+        index_source_file = source_directory / "index.rst"
+        markdown_source_file = source_directory / "markdown_document.md"
+        (source_directory / "conf.py").touch()
+        index_source_file_content = dedent(
+            text="""\
+            .. toctree::
+
+               markdown_document
+            """,
+        )
+        markdown_source_file_content = dedent(
+            text="""\
+            # Title
+
+            ```{code-block}
+            :substitutions:
+
+            |key.with.dots|
+            ```
+            """,
+        )
+        index_source_file.write_text(data=index_source_file_content)
+        markdown_source_file.write_text(data=markdown_source_file_content)
+
+        app = make_app(
+            srcdir=source_directory,
+            exception_on_warning=True,
+            confoverrides={
+                "extensions": [
+                    "myst_parser",
+                    "sphinx_substitution_extensions",
+                ],
+                "myst_enable_extensions": ["substitution"],
+                "myst_substitutions": {
+                    "key.with.dots": "value",
+                },
+            },
+        )
+
+        with pytest.raises(
+            expected_exception=SphinxError,
+            match=r"Substitution key 'key\.with\.dots' contains a dot",
+        ):
+            app.build()
+
+    @staticmethod
+    def test_myst_nested_substitution_key_with_dot_raises_error(
+        *,
+        tmp_path: Path,
+        make_app: Callable[..., SphinxTestApp],
+    ) -> None:
+        """MyST nested substitution keys containing dots raise SphinxError.
+
+        Dots are reserved for nested access notation.
+        """
+        source_directory = tmp_path / "source"
+        source_directory.mkdir()
+        index_source_file = source_directory / "index.rst"
+        markdown_source_file = source_directory / "markdown_document.md"
+        (source_directory / "conf.py").touch()
+        index_source_file_content = dedent(
+            text="""\
+            .. toctree::
+
+               markdown_document
+            """,
+        )
+        markdown_source_file_content = dedent(
+            text="""\
+            # Title
+
+            ```{code-block}
+            :substitutions:
+
+            |parent.key.with.dots|
+            ```
+            """,
+        )
+        index_source_file.write_text(data=index_source_file_content)
+        markdown_source_file.write_text(data=markdown_source_file_content)
+
+        app = make_app(
+            srcdir=source_directory,
+            exception_on_warning=True,
+            confoverrides={
+                "extensions": [
+                    "myst_parser",
+                    "sphinx_substitution_extensions",
+                ],
+                "myst_enable_extensions": ["substitution"],
+                "myst_substitutions": {
+                    "parent": {
+                        "key.with.dots": "value",
+                    },
+                },
+            },
+        )
+
+        with pytest.raises(
+            expected_exception=SphinxError,
+            match=r"Substitution key 'key\.with\.dots' contains a dot",
+        ):
+            app.build()
 
 
 def test_xref_role_class_prefix_removal(

--- a/tests/test_substitution_extensions.py
+++ b/tests/test_substitution_extensions.py
@@ -2213,6 +2213,67 @@ class TestMyst:
         ):
             app.build()
 
+    @staticmethod
+    def test_rst_substitution_key_with_dot_does_not_raise_error(
+        *,
+        tmp_path: Path,
+        make_app: Callable[..., SphinxTestApp],
+    ) -> None:
+        """Substitution names with dots do not raise SphinxError in reST.
+
+        The dot validation applies only to flattened MyST substitutions, so
+        a refactoring that leaked it into the reST path would be caught here.
+        """
+        source_directory = tmp_path / "source"
+        source_directory.mkdir()
+        source_file = source_directory / "index.rst"
+        (source_directory / "conf.py").touch()
+
+        source_file_content = dedent(
+            text="""\
+            .. |key.with.dots| replace:: example_substitution
+
+            .. code-block:: shell
+               :substitutions:
+
+               $ PRE-|key.with.dots|-POST
+            """,
+        )
+        source_file.write_text(data=source_file_content)
+        app = make_app(
+            srcdir=source_directory,
+            exception_on_warning=True,
+            confoverrides={
+                "extensions": ["sphinx_substitution_extensions"],
+            },
+        )
+        app.build()
+        assert app.statuscode == 0
+        content_html = (app.outdir / "index.html").read_text()
+        app.cleanup()
+
+        equivalent_source = dedent(
+            text="""\
+            .. code-block:: shell
+
+                $ PRE-example_substitution-POST
+            """,
+        )
+
+        source_file.write_text(data=equivalent_source)
+        app_expected = make_app(
+            srcdir=source_directory,
+            exception_on_warning=True,
+            freshenv=True,
+        )
+        app_expected.build()
+        assert app_expected.statuscode == 0
+
+        expected_content_html = (
+            app_expected.outdir / "index.html"
+        ).read_text()
+        assert content_html == expected_content_html
+
 
 def test_xref_role_class_prefix_removal(
     *,

--- a/tests/test_substitution_extensions.py
+++ b/tests/test_substitution_extensions.py
@@ -1702,7 +1702,8 @@ class TestMyst:
         tmp_path: Path,
         make_app: Callable[..., SphinxTestApp],
     ) -> None:
-        """MyST empty containers (lists and dictionaries) do not create keys
+        """MyST empty containers (lists and dictionaries) do not create
+        keys
         and do not break the build.
         """
         source_directory = tmp_path / "source"

--- a/tests/test_substitution_extensions.py
+++ b/tests/test_substitution_extensions.py
@@ -1609,6 +1609,491 @@ class TestMyst:
         ).read_text()
         assert content_html == expected_content_html
 
+    @staticmethod
+    def test_myst_deep_nesting(
+        *,
+        tmp_path: Path,
+        make_app: Callable[..., SphinxTestApp],
+    ) -> None:
+        """MyST deeply nested substitutions (5 levels) are flattened
+        correctly.
+        """
+        source_directory = tmp_path / "source"
+        source_directory.mkdir()
+        index_source_file = source_directory / "index.rst"
+        markdown_source_file = source_directory / "markdown_document.md"
+        (source_directory / "conf.py").touch()
+        index_source_file_content = dedent(
+            text="""\
+            .. toctree::
+
+               markdown_document
+            """,
+        )
+        markdown_source_file_content = dedent(
+            text="""\
+            # Title
+
+            ```{code-block}
+            :substitutions:
+
+            $ PRE-|level1.level2.level3.level4.level5|-POST
+            ```
+            """,
+        )
+        index_source_file.write_text(data=index_source_file_content)
+        markdown_source_file.write_text(data=markdown_source_file_content)
+
+        app = make_app(
+            srcdir=source_directory,
+            exception_on_warning=True,
+            confoverrides={
+                "extensions": [
+                    "myst_parser",
+                    "sphinx_substitution_extensions",
+                ],
+                "myst_enable_extensions": ["substitution"],
+                "myst_substitutions": {
+                    "level1": {
+                        "level2": {
+                            "level3": {
+                                "level4": {
+                                    "level5": "deep_value",
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        )
+        app.build()
+        assert app.statuscode == 0
+        content_html = (app.outdir / "markdown_document.html").read_text()
+        app.cleanup()
+
+        equivalent_source = dedent(
+            text="""\
+            # Title
+
+            ```{code-block}
+
+            $ PRE-deep_value-POST
+            ```
+            """,
+        )
+
+        markdown_source_file.write_text(data=equivalent_source)
+        app_expected = make_app(
+            srcdir=source_directory,
+            exception_on_warning=True,
+            confoverrides={"extensions": ["myst_parser"]},
+        )
+        app_expected.build()
+        assert app_expected.statuscode == 0
+
+        expected_content_html = (
+            app_expected.outdir / "markdown_document.html"
+        ).read_text()
+        assert content_html == expected_content_html
+
+    @staticmethod
+    def test_myst_empty_containers(
+        *,
+        tmp_path: Path,
+        make_app: Callable[..., SphinxTestApp],
+    ) -> None:
+        """MyST empty containers (lists and dicts) do not create keys
+        and do not break the build.
+        """
+        source_directory = tmp_path / "source"
+        source_directory.mkdir()
+        index_source_file = source_directory / "index.rst"
+        markdown_source_file = source_directory / "markdown_document.md"
+        (source_directory / "conf.py").touch()
+        index_source_file_content = dedent(
+            text="""\
+            .. toctree::
+
+               markdown_document
+            """,
+        )
+        markdown_source_file_content = dedent(
+            text="""\
+            # Title
+
+            ```{code-block}
+            :substitutions:
+
+            $ PRE-|normal|-POST
+            ```
+
+            ```{code-block}
+            :substitutions:
+
+            $ PRE-|mixed.normal|-POST
+            ```
+            """,
+        )
+        index_source_file.write_text(data=index_source_file_content)
+        markdown_source_file.write_text(data=markdown_source_file_content)
+
+        app = make_app(
+            srcdir=source_directory,
+            exception_on_warning=True,
+            confoverrides={
+                "extensions": [
+                    "myst_parser",
+                    "sphinx_substitution_extensions",
+                ],
+                "myst_enable_extensions": ["substitution"],
+                "myst_substitutions": {
+                    "empty_list": [],
+                    "empty_dict": {},
+                    "mixed": {
+                        "empty_nested_list": [],
+                        "empty_nested_dict": {},
+                        "normal": "value",
+                    },
+                    "normal": "normal_value",
+                },
+            },
+        )
+        app.build()
+        assert app.statuscode == 0
+        content_html = (app.outdir / "markdown_document.html").read_text()
+        app.cleanup()
+
+        equivalent_source = dedent(
+            text="""\
+            # Title
+
+            ```{code-block}
+
+            $ PRE-normal_value-POST
+            ```
+
+            ```{code-block}
+
+            $ PRE-value-POST
+            ```
+            """,
+        )
+
+        markdown_source_file.write_text(data=equivalent_source)
+        app_expected = make_app(
+            srcdir=source_directory,
+            exception_on_warning=True,
+            confoverrides={"extensions": ["myst_parser"]},
+        )
+        app_expected.build()
+        assert app_expected.statuscode == 0
+
+        expected_content_html = (
+            app_expected.outdir / "markdown_document.html"
+        ).read_text()
+        assert content_html == expected_content_html
+
+    @staticmethod
+    def test_myst_mixed_types_in_list(
+        *,
+        tmp_path: Path,
+        make_app: Callable[..., SphinxTestApp],
+    ) -> None:
+        """MyST mixed types in lists are converted to strings
+        correctly.
+        """
+        source_directory = tmp_path / "source"
+        source_directory.mkdir()
+        index_source_file = source_directory / "index.rst"
+        markdown_source_file = source_directory / "markdown_document.md"
+        (source_directory / "conf.py").touch()
+        index_source_file_content = dedent(
+            text="""\
+            .. toctree::
+
+               markdown_document
+            """,
+        )
+        markdown_source_file_content = dedent(
+            text="""\
+            # Title
+
+            ```{code-block}
+            :substitutions:
+
+            $ PRE-|mixed.0|-POST
+            ```
+
+            ```{code-block}
+            :substitutions:
+
+            $ PRE-|mixed.1|-POST
+            ```
+
+            ```{code-block}
+            :substitutions:
+
+            $ PRE-|mixed.2|-POST
+            ```
+
+            ```{code-block}
+            :substitutions:
+
+            $ PRE-|mixed.3|-POST
+            ```
+
+            ```{code-block}
+            :substitutions:
+
+            $ PRE-|mixed.4|-POST
+            ```
+            """,
+        )
+        index_source_file.write_text(data=index_source_file_content)
+        markdown_source_file.write_text(data=markdown_source_file_content)
+
+        app = make_app(
+            srcdir=source_directory,
+            exception_on_warning=True,
+            confoverrides={
+                "extensions": [
+                    "myst_parser",
+                    "sphinx_substitution_extensions",
+                ],
+                "myst_enable_extensions": ["substitution"],
+                "myst_substitutions": {
+                    "mixed": [1, "text", 3.14, -42, 0],
+                },
+            },
+        )
+        app.build()
+        assert app.statuscode == 0
+        content_html = (app.outdir / "markdown_document.html").read_text()
+        app.cleanup()
+
+        equivalent_source = dedent(
+            text="""\
+            # Title
+
+            ```{code-block}
+
+            $ PRE-1-POST
+            ```
+
+            ```{code-block}
+
+            $ PRE-text-POST
+            ```
+
+            ```{code-block}
+
+            $ PRE-3.14-POST
+            ```
+
+            ```{code-block}
+
+            $ PRE--42-POST
+            ```
+
+            ```{code-block}
+
+            $ PRE-0-POST
+            ```
+            """,
+        )
+
+        markdown_source_file.write_text(data=equivalent_source)
+        app_expected = make_app(
+            srcdir=source_directory,
+            exception_on_warning=True,
+            confoverrides={"extensions": ["myst_parser"]},
+        )
+        app_expected.build()
+        assert app_expected.statuscode == 0
+
+        expected_content_html = (
+            app_expected.outdir / "markdown_document.html"
+        ).read_text()
+        assert content_html == expected_content_html
+
+    @staticmethod
+    def test_myst_nested_lists(
+        *,
+        tmp_path: Path,
+        make_app: Callable[..., SphinxTestApp],
+    ) -> None:
+        """MyST nested lists are flattened with multi-index notation."""
+        source_directory = tmp_path / "source"
+        source_directory.mkdir()
+        index_source_file = source_directory / "index.rst"
+        markdown_source_file = source_directory / "markdown_document.md"
+        (source_directory / "conf.py").touch()
+        index_source_file_content = dedent(
+            text="""\
+            .. toctree::
+
+               markdown_document
+            """,
+        )
+        markdown_source_file_content = dedent(
+            text="""\
+            # Title
+
+            ```{code-block}
+            :substitutions:
+
+            $ PRE-|matrix.0.0|-POST
+            ```
+
+            ```{code-block}
+            :substitutions:
+
+            $ PRE-|matrix.0.1|-POST
+            ```
+
+            ```{code-block}
+            :substitutions:
+
+            $ PRE-|matrix.1.0|-POST
+            ```
+
+            ```{code-block}
+            :substitutions:
+
+            $ PRE-|matrix.1.1|-POST
+            ```
+            """,
+        )
+        index_source_file.write_text(data=index_source_file_content)
+        markdown_source_file.write_text(data=markdown_source_file_content)
+
+        app = make_app(
+            srcdir=source_directory,
+            exception_on_warning=True,
+            confoverrides={
+                "extensions": [
+                    "myst_parser",
+                    "sphinx_substitution_extensions",
+                ],
+                "myst_enable_extensions": ["substitution"],
+                "myst_substitutions": {
+                    "matrix": [
+                        [1, 2],
+                        [3, 4],
+                    ],
+                },
+            },
+        )
+        app.build()
+        assert app.statuscode == 0
+        content_html = (app.outdir / "markdown_document.html").read_text()
+        app.cleanup()
+
+        equivalent_source = dedent(
+            text="""\
+            # Title
+
+            ```{code-block}
+
+            $ PRE-1-POST
+            ```
+
+            ```{code-block}
+
+            $ PRE-2-POST
+            ```
+
+            ```{code-block}
+
+            $ PRE-3-POST
+            ```
+
+            ```{code-block}
+
+            $ PRE-4-POST
+            ```
+            """,
+        )
+
+        markdown_source_file.write_text(data=equivalent_source)
+        app_expected = make_app(
+            srcdir=source_directory,
+            exception_on_warning=True,
+            confoverrides={"extensions": ["myst_parser"]},
+        )
+        app_expected.build()
+        assert app_expected.statuscode == 0
+
+        expected_content_html = (
+            app_expected.outdir / "markdown_document.html"
+        ).read_text()
+        assert content_html == expected_content_html
+
+    @staticmethod
+    def test_myst_invalid_substitution_access(
+        *,
+        tmp_path: Path,
+        make_app: Callable[..., SphinxTestApp],
+    ) -> None:
+        """MyST invalid substitution access does not break the build."""
+        source_directory = tmp_path / "source"
+        source_directory.mkdir()
+        index_source_file = source_directory / "index.rst"
+        markdown_source_file = source_directory / "markdown_document.md"
+        (source_directory / "conf.py").touch()
+        index_source_file_content = dedent(
+            text="""\
+            .. toctree::
+
+               markdown_document
+            """,
+        )
+        markdown_source_file_content = dedent(
+            text="""\
+            # Title
+
+            ```{code-block}
+            :substitutions:
+
+            $ PRE-|items.99|-POST
+            ```
+
+            ```{code-block}
+            :substitutions:
+
+            $ PRE-|nonexistent.key|-POST
+            ```
+            """,
+        )
+        index_source_file.write_text(data=index_source_file_content)
+        markdown_source_file.write_text(data=markdown_source_file_content)
+
+        app = make_app(
+            srcdir=source_directory,
+            exception_on_warning=False,
+            confoverrides={
+                "extensions": [
+                    "myst_parser",
+                    "sphinx_substitution_extensions",
+                ],
+                "myst_enable_extensions": ["substitution"],
+                "myst_substitutions": {
+                    "items": ["a", "b"],
+                },
+            },
+        )
+        app.build()
+        assert app.statuscode == 0
+        content_html = (app.outdir / "markdown_document.html").read_text()
+        app.cleanup()
+
+        expected_text_in_html = [
+            "$ PRE-|items.99|-POST",
+            "$ PRE-|nonexistent.key|-POST",
+        ]
+        for text in expected_text_in_html:
+            assert text in content_html
+
 
 def test_xref_role_class_prefix_removal(
     *,

--- a/tests/test_substitution_extensions.py
+++ b/tests/test_substitution_extensions.py
@@ -1493,6 +1493,122 @@ class TestMyst:
         ).read_text()
         assert content_html == expected_content_html
 
+    @staticmethod
+    def test_myst_nested_substitutions_with_lists(
+        *,
+        tmp_path: Path,
+        make_app: Callable[..., SphinxTestApp],
+    ) -> None:
+        """MyST nested substitutions with lists are flattened and
+        applied correctly.
+        """
+        source_directory = tmp_path / "source"
+        source_directory.mkdir()
+        index_source_file = source_directory / "index.rst"
+        markdown_source_file = source_directory / "markdown_document.md"
+        (source_directory / "conf.py").touch()
+        index_source_file_content = dedent(
+            text="""\
+            .. toctree::
+
+               markdown_document
+            """,
+        )
+        markdown_source_file_content = dedent(
+            text="""\
+            # Title
+
+            ```{code-block}
+            :substitutions:
+
+            $ PRE-|items.0|-POST
+            ```
+
+            ```{code-block}
+            :substitutions:
+
+            $ PRE-|items.1|-POST
+            ```
+
+            ```{code-block}
+            :substitutions:
+
+            $ PRE-|nested.0.name|-POST
+            ```
+
+            ```{code-block}
+            :substitutions:
+
+            $ PRE-|nested.1.value|-POST
+            ```
+            """,
+        )
+        index_source_file.write_text(data=index_source_file_content)
+        markdown_source_file.write_text(data=markdown_source_file_content)
+
+        app = make_app(
+            srcdir=source_directory,
+            exception_on_warning=True,
+            confoverrides={
+                "extensions": [
+                    "myst_parser",
+                    "sphinx_substitution_extensions",
+                ],
+                "myst_enable_extensions": ["substitution"],
+                "myst_substitutions": {
+                    "items": ["first", "second"],
+                    "nested": [
+                        {"name": "a", "value": "1"},
+                        {"name": "b", "value": "2"},
+                    ],
+                },
+            },
+        )
+        app.build()
+        assert app.statuscode == 0
+        content_html = (app.outdir / "markdown_document.html").read_text()
+        app.cleanup()
+
+        equivalent_source = dedent(
+            text="""\
+            # Title
+
+            ```{code-block}
+
+            $ PRE-first-POST
+            ```
+
+            ```{code-block}
+
+            $ PRE-second-POST
+            ```
+
+            ```{code-block}
+
+            $ PRE-a-POST
+            ```
+
+            ```{code-block}
+
+            $ PRE-2-POST
+            ```
+            """,
+        )
+
+        markdown_source_file.write_text(data=equivalent_source)
+        app_expected = make_app(
+            srcdir=source_directory,
+            exception_on_warning=True,
+            confoverrides={"extensions": ["myst_parser"]},
+        )
+        app_expected.build()
+        assert app_expected.statuscode == 0
+
+        expected_content_html = (
+            app_expected.outdir / "markdown_document.html"
+        ).read_text()
+        assert content_html == expected_content_html
+
 
 def test_xref_role_class_prefix_removal(
     *,

--- a/tests/test_substitution_extensions.py
+++ b/tests/test_substitution_extensions.py
@@ -1386,6 +1386,113 @@ class TestMyst:
         ).read_text()
         assert content_html == expected_content_html
 
+    @staticmethod
+    def test_myst_nested_substitutions(
+        *,
+        tmp_path: Path,
+        make_app: Callable[..., SphinxTestApp],
+    ) -> None:
+        """MyST nested substitutions are flattened and applied
+        correctly.
+        """
+        source_directory = tmp_path / "source"
+        source_directory.mkdir()
+        index_source_file = source_directory / "index.rst"
+        markdown_source_file = source_directory / "markdown_document.md"
+        (source_directory / "conf.py").touch()
+        index_source_file_content = dedent(
+            text="""\
+            .. toctree::
+
+               markdown_document
+            """,
+        )
+        markdown_source_file_content = dedent(
+            text="""\
+            # Title
+
+            ```{code-block}
+            :substitutions:
+
+            $ PRE-|a|-POST
+            ```
+
+            ```{code-block}
+            :substitutions:
+
+            $ PRE-|b.c|-POST
+            ```
+
+            ```{code-block}
+            :substitutions:
+
+            $ PRE-|b.d.e|-POST
+            ```
+            """,
+        )
+        index_source_file.write_text(data=index_source_file_content)
+        markdown_source_file.write_text(data=markdown_source_file_content)
+
+        app = make_app(
+            srcdir=source_directory,
+            exception_on_warning=True,
+            confoverrides={
+                "extensions": [
+                    "myst_parser",
+                    "sphinx_substitution_extensions",
+                ],
+                "myst_enable_extensions": ["substitution"],
+                "myst_substitutions": {
+                    "a": "value_a",
+                    "b": {
+                        "c": "value_b_c",
+                        "d": {
+                            "e": "value_b_d_e",
+                        },
+                    },
+                },
+            },
+        )
+        app.build()
+        assert app.statuscode == 0
+        content_html = (app.outdir / "markdown_document.html").read_text()
+        app.cleanup()
+
+        equivalent_source = dedent(
+            text="""\
+            # Title
+
+            ```{code-block}
+
+            $ PRE-value_a-POST
+            ```
+
+            ```{code-block}
+
+            $ PRE-value_b_c-POST
+            ```
+
+            ```{code-block}
+
+            $ PRE-value_b_d_e-POST
+            ```
+            """,
+        )
+
+        markdown_source_file.write_text(data=equivalent_source)
+        app_expected = make_app(
+            srcdir=source_directory,
+            exception_on_warning=True,
+            confoverrides={"extensions": ["myst_parser"]},
+        )
+        app_expected.build()
+        assert app_expected.statuscode == 0
+
+        expected_content_html = (
+            app_expected.outdir / "markdown_document.html"
+        ).read_text()
+        assert content_html == expected_content_html
+
 
 def test_xref_role_class_prefix_removal(
     *,


### PR DESCRIPTION
Adds support for nested substitutions in MyST parser configuration. Nested dictionary structures are automatically flattened using dot notation.

Example:
```python
myst_substitutions = {
    "a": "value_a",
    "b": {"c": "value_b_c", "d": {"e": "value_b_d_e"}}
}
# Flattens to: {"a": "value_a", "b.c": "value_b_c", "b.d.e": "value_b_d_e"}
```