### PR TITLE
Add include content substitutions

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -53,13 +53,16 @@ discovered automatically by doc8 and reads additional ignores from
    [tool.doc8]
    ignore-messages = [
        """Error in "include" directive:
+   unknown option: "content-substitutions".""",
+       """Error in "include" directive:
    unknown option: "path-substitutions".""",
    ]
 
-This ignores the diagnostic for ``include``'s ``:path-substitutions:`` option.
-Plain docutils does not know about that option, but this extension adds it when
-Sphinx builds the documentation. Keep this as an exact-message ignore so other
-``D000`` diagnostics remain visible.
+This ignores diagnostics for ``include``'s ``:content-substitutions:`` and
+``:path-substitutions:`` options. Plain docutils does not know about those
+options, but this extension adds them when Sphinx builds the documentation.
+Keep these as exact-message ignores so other ``D000`` diagnostics remain
+visible.
 
 .. _Homebrew: https://brew.sh
 .. _doc8-custom-ignores: https://adamtheturtle.github.io/doc8-custom-ignores/

--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,15 @@ Replace substitutions in the file path:
 ``include``
 ~~~~~~~~~~~
 
-This adds a ``:path-substitutions:`` option to docutils' built-in `include`_ directive.
+This adds ``:content-substitutions:`` and ``:path-substitutions:`` options to
+docutils' built-in `include`_ directive.
+
+Replace substitutions in the included source content before it is parsed:
+
+.. code-block:: rst
+
+   .. include:: path/to/file.rst
+      :content-substitutions:
 
 Replace substitutions in the file path:
 
@@ -146,7 +154,10 @@ This will replace ``|release|`` in the new directives with ``0.1``, and ``|autho
 Enabling substitutions by default
 ----------------------------------
 
-By default, you need to explicitly add the ``:substitutions:`` flag to ``code-block`` directives, and ``:path-substitutions:`` flags to ``literalinclude``, ``include``, and ``image`` directives (or ``:content-substitutions:`` for ``literalinclude``).
+By default, you need to explicitly add the ``:substitutions:`` flag to
+``code-block`` directives, ``:content-substitutions:`` or
+``:path-substitutions:`` flags to ``literalinclude`` and ``include``
+directives, and ``:path-substitutions:`` to ``image`` directives.
 
 If you want substitutions to be applied by default without needing these flags, you can set the following in ``conf.py``:
 
@@ -160,7 +171,7 @@ When this is enabled:
 
 - All ``code-block`` directives will have substitutions applied automatically
 - All ``literalinclude`` directives will have both content and path substitutions applied automatically
-- All ``include`` directives will have path substitutions applied automatically
+- All ``include`` directives will have both content and path substitutions applied automatically
 - All ``image`` directives will have path substitutions applied automatically
 
 You can disable substitutions for specific directives when the default is enabled:
@@ -179,6 +190,7 @@ You can disable substitutions for specific directives when the default is enable
       :nopath-substitutions:
 
    .. include:: path/to/|literal|_file.txt
+      :nocontent-substitutions:
       :nopath-substitutions:
 
    .. image:: path/to/|literal|_diagram.png

--- a/newsfragments/121.change
+++ b/newsfragments/121.change
@@ -1,0 +1,1 @@
+Add content substitutions to the ``include`` directive with ``:content-substitutions:`` and ``:nocontent-substitutions:`` options.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -398,6 +398,8 @@ linewrap-full-docstring = true
 max_line_length = 2000
 ignore-messages = [
     '''Error in "include" directive:
+unknown option: "content-substitutions".''',
+    '''Error in "include" directive:
 unknown option: "path-substitutions".''',
 ]
 ignore_path = [

--- a/sample/source/index.rst
+++ b/sample/source/index.rst
@@ -65,6 +65,12 @@ Path substitutions
 ``include``
 -----------
 
+Content substitutions
+~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: sample_content_include.txt
+   :content-substitutions:
+
 Path substitutions
 ~~~~~~~~~~~~~~~~~~
 

--- a/sample/source/sample_content_include.txt
+++ b/sample/source/sample_content_include.txt
@@ -1,0 +1,3 @@
+.. code-block:: text
+
+   The author is |author|.

--- a/src/sphinx_substitution_extensions/__init__.py
+++ b/src/sphinx_substitution_extensions/__init__.py
@@ -2,6 +2,7 @@
 
 from importlib.metadata import version
 from typing import Any, ClassVar, TypeAlias
+from unittest.mock import patch
 
 from beartype import beartype
 from docutils.nodes import (
@@ -436,46 +437,95 @@ class SubstitutionInclude(Include):
 
     option_spec: ClassVar[OptionSpec | None] = {
         **(Include.option_spec or {}),
+        CONTENT_SUBSTITUTION_OPTION_NAME: directives.flag,
         PATH_SUBSTITUTION_OPTION_NAME: directives.flag,
+        NO_CONTENT_SUBSTITUTION_OPTION_NAME: directives.flag,
         NO_PATH_SUBSTITUTION_OPTION_NAME: directives.flag,
     }
 
     def run(self) -> list[Node]:
-        """Replace placeholders with given variables in the file path."""
+        """Replace placeholders in the path and/or included content."""
         env = self.state.document.settings.env
 
-        if env is not None:
-            config = env.config
+        if env is None:
+            return list(super().run())
 
-            should_apply_path_substitutions = _should_apply_substitutions(
-                options=self.options,
-                config=config,
-                yes_flag=PATH_SUBSTITUTION_OPTION_NAME,
-                no_flag=NO_PATH_SUBSTITUTION_OPTION_NAME,
+        config = env.config
+        should_apply_path_substitutions = _should_apply_substitutions(
+            options=self.options,
+            config=config,
+            yes_flag=PATH_SUBSTITUTION_OPTION_NAME,
+            no_flag=NO_PATH_SUBSTITUTION_OPTION_NAME,
+        )
+        should_apply_content_substitutions = _should_apply_substitutions(
+            options=self.options,
+            config=config,
+            yes_flag=CONTENT_SUBSTITUTION_OPTION_NAME,
+            no_flag=NO_CONTENT_SUBSTITUTION_OPTION_NAME,
+        )
+
+        if not (
+            should_apply_path_substitutions
+            or should_apply_content_substitutions
+        ):
+            return list(super().run())
+
+        substitution_defs = _get_substitution_defs(
+            env=env,
+            config=config,
+            substitution_defs=self.state.document.substitution_defs,
+        )
+        delimiter_pairs = _get_delimiter_pairs(
+            env=env,
+            config=config,
+        )
+
+        if should_apply_path_substitutions:
+            for argument_index, argument in enumerate(iterable=self.arguments):
+                self.arguments[argument_index] = _apply_substitutions(
+                    text=argument,
+                    substitution_defs=substitution_defs,
+                    delimiter_pairs=delimiter_pairs,
+                )
+
+        if not should_apply_content_substitutions:
+            return list(super().run())
+
+        original_insert_input = self.state_machine.insert_input
+
+        def insert_substituted_input(
+            input_lines: list[str],
+            source: str,
+        ) -> None:
+            """Insert included lines after applying substitutions."""
+            substituted_lines = [
+                _apply_substitutions(
+                    text=line,
+                    substitution_defs=substitution_defs,
+                    delimiter_pairs=delimiter_pairs,
+                )
+                for line in input_lines
+            ]
+            original_insert_input(
+                input_lines=substituted_lines,
+                source=source,
             )
 
-            if should_apply_path_substitutions:
-                substitution_defs = _get_substitution_defs(
-                    env=env,
-                    config=config,
-                    substitution_defs=self.state.document.substitution_defs,
-                )
+        with patch.object(
+            target=self.state_machine,
+            attribute="insert_input",
+            new=insert_substituted_input,
+        ):
+            nodes_list = list(super().run())
 
-                delimiter_pairs = _get_delimiter_pairs(
-                    env=env,
-                    config=config,
-                )
+        for node in nodes_list:
+            _process_node(
+                node=node,
+                substitution_defs=substitution_defs,
+                delimiter_pairs=delimiter_pairs,
+            )
 
-                for argument_index, argument in enumerate(
-                    iterable=self.arguments
-                ):
-                    self.arguments[argument_index] = _apply_substitutions(
-                        text=argument,
-                        substitution_defs=substitution_defs,
-                        delimiter_pairs=delimiter_pairs,
-                    )
-
-        return list(super().run())
+        return nodes_list
 
 
 @beartype

--- a/tests/test_substitution_extensions.py
+++ b/tests/test_substitution_extensions.py
@@ -2443,7 +2443,8 @@ def test_substitution_include_content(
     source_directory = tmp_path / "source"
     source_directory.mkdir()
     (source_directory / "conf.py").touch()
-    (source_directory / "upgrade-guide.txt").write_text(
+    include_file = source_directory / "upgrade-guide.txt"
+    include_file.write_text(
         data=dedent(
             text="""\
             .. code-block:: shell
@@ -2452,7 +2453,8 @@ def test_substitution_include_content(
             """,
         ),
     )
-    (source_directory / "index.rst").write_text(
+    source_file = source_directory / "index.rst"
+    source_file.write_text(
         data=dedent(
             text="""\
             .. |SRC_VERSION| replace:: 4.0
@@ -2470,11 +2472,30 @@ def test_substitution_include_content(
         confoverrides={"extensions": ["sphinx_substitution_extensions"]},
     )
     app.build()
+    assert app.statuscode == 0
+    content_html = (app.outdir / "index.html").read_text()
+    app.cleanup()
 
-    output = app.env.get_doctree(docname="index").astext()
-    assert "upgrade --from 4.0 --to 4.1" in output
-    assert "|SRC_VERSION|" not in output
-    assert "|NEW_VERSION|" not in output
+    include_file.write_text(
+        data=dedent(
+            text="""\
+            .. code-block:: shell
+
+               upgrade --from 4.0 --to 4.1
+            """,
+        ),
+    )
+    source_file.write_text(data=".. include:: upgrade-guide.txt\n")
+
+    app_expected = make_app(
+        srcdir=source_directory,
+        exception_on_warning=True,
+    )
+    app_expected.build()
+    assert app_expected.statuscode == 0
+
+    expected_content_html = (app_expected.outdir / "index.html").read_text()
+    assert content_html == expected_content_html
 
 
 def test_substitution_include_path_and_content(
@@ -2486,7 +2507,8 @@ def test_substitution_include_path_and_content(
     source_directory = tmp_path / "source"
     source_directory.mkdir()
     (source_directory / "conf.py").touch()
-    (source_directory / "upgrade-guide.txt").write_text(
+    include_file = source_directory / "upgrade-guide.txt"
+    include_file.write_text(
         data=dedent(
             text="""\
             .. code-block:: text
@@ -2495,7 +2517,8 @@ def test_substitution_include_path_and_content(
             """,
         ),
     )
-    (source_directory / "index.rst").write_text(
+    source_file = source_directory / "index.rst"
+    source_file.write_text(
         data=dedent(
             text="""\
             .. |document| replace:: upgrade-guide
@@ -2514,10 +2537,30 @@ def test_substitution_include_path_and_content(
         confoverrides={"extensions": ["sphinx_substitution_extensions"]},
     )
     app.build()
+    assert app.statuscode == 0
+    content_html = (app.outdir / "index.html").read_text()
+    app.cleanup()
 
-    output = app.env.get_doctree(docname="index").astext()
-    assert "Upgrade to 4.1." in output
-    assert "|version|" not in output
+    include_file.write_text(
+        data=dedent(
+            text="""\
+            .. code-block:: text
+
+               Upgrade to 4.1.
+            """,
+        ),
+    )
+    source_file.write_text(data=".. include:: upgrade-guide.txt\n")
+
+    app_expected = make_app(
+        srcdir=source_directory,
+        exception_on_warning=True,
+    )
+    app_expected.build()
+    assert app_expected.statuscode == 0
+
+    expected_content_html = (app_expected.outdir / "index.html").read_text()
+    assert content_html == expected_content_html
 
 
 def test_substitution_include_literal_content(
@@ -2529,10 +2572,12 @@ def test_substitution_include_literal_content(
     source_directory = tmp_path / "source"
     source_directory.mkdir()
     (source_directory / "conf.py").touch()
-    (source_directory / "example.txt").write_text(
+    include_file = source_directory / "example.txt"
+    include_file.write_text(
         data="Content with |name| placeholder",
     )
-    (source_directory / "index.rst").write_text(
+    source_file = source_directory / "index.rst"
+    source_file.write_text(
         data=dedent(
             text="""\
             .. |name| replace:: example
@@ -2550,10 +2595,29 @@ def test_substitution_include_literal_content(
         confoverrides={"extensions": ["sphinx_substitution_extensions"]},
     )
     app.build()
+    assert app.statuscode == 0
+    content_html = (app.outdir / "index.html").read_text()
+    app.cleanup()
 
-    output = app.env.get_doctree(docname="index").astext()
-    assert "Content with example placeholder" in output
-    assert "|name|" not in output
+    include_file.write_text(data="Content with example placeholder")
+    source_file.write_text(
+        data=dedent(
+            text="""\
+            .. include:: example.txt
+               :literal:
+            """,
+        ),
+    )
+
+    app_expected = make_app(
+        srcdir=source_directory,
+        exception_on_warning=True,
+    )
+    app_expected.build()
+    assert app_expected.statuscode == 0
+
+    expected_content_html = (app_expected.outdir / "index.html").read_text()
+    assert content_html == expected_content_html
 
 
 def test_default_substitution_include_path(
@@ -2601,7 +2665,8 @@ def test_default_substitution_include_content(
     source_directory = tmp_path / "source"
     source_directory.mkdir()
     (source_directory / "conf.py").touch()
-    (source_directory / "example.txt").write_text(
+    include_file = source_directory / "example.txt"
+    include_file.write_text(
         data=dedent(
             text="""\
             Included literal content::
@@ -2610,7 +2675,8 @@ def test_default_substitution_include_content(
             """,
         ),
     )
-    (source_directory / "index.rst").write_text(
+    source_file = source_directory / "index.rst"
+    source_file.write_text(
         data=dedent(
             text="""\
             .. |name| replace:: example
@@ -2629,10 +2695,30 @@ def test_default_substitution_include_content(
         },
     )
     app.build()
+    assert app.statuscode == 0
+    content_html = (app.outdir / "index.html").read_text()
+    app.cleanup()
 
-    output = app.env.get_doctree(docname="index").astext()
-    assert "Content with example placeholder" in output
-    assert "|name|" not in output
+    include_file.write_text(
+        data=dedent(
+            text="""\
+            Included literal content::
+
+               Content with example placeholder
+            """,
+        ),
+    )
+    source_file.write_text(data=".. include:: example.txt\n")
+
+    app_expected = make_app(
+        srcdir=source_directory,
+        exception_on_warning=True,
+    )
+    app_expected.build()
+    assert app_expected.statuscode == 0
+
+    expected_content_html = (app_expected.outdir / "index.html").read_text()
+    assert content_html == expected_content_html
 
 
 def test_default_substitution_include_disabled_content(
@@ -2644,7 +2730,8 @@ def test_default_substitution_include_disabled_content(
     source_directory = tmp_path / "source"
     source_directory.mkdir()
     (source_directory / "conf.py").touch()
-    (source_directory / "example.txt").write_text(
+    include_file = source_directory / "example.txt"
+    include_file.write_text(
         data=dedent(
             text="""\
             Included literal content::
@@ -2653,7 +2740,8 @@ def test_default_substitution_include_disabled_content(
             """,
         ),
     )
-    (source_directory / "index.rst").write_text(
+    source_file = source_directory / "index.rst"
+    source_file.write_text(
         data=dedent(
             text="""\
             .. |name| replace:: example
@@ -2673,9 +2761,21 @@ def test_default_substitution_include_disabled_content(
         },
     )
     app.build()
+    assert app.statuscode == 0
+    content_html = (app.outdir / "index.html").read_text()
+    app.cleanup()
 
-    output = app.env.get_doctree(docname="index").astext()
-    assert "Content with |name| placeholder" in output
+    source_file.write_text(data=".. include:: example.txt\n")
+
+    app_expected = make_app(
+        srcdir=source_directory,
+        exception_on_warning=True,
+    )
+    app_expected.build()
+    assert app_expected.statuscode == 0
+
+    expected_content_html = (app_expected.outdir / "index.html").read_text()
+    assert content_html == expected_content_html
 
 
 def test_default_substitution_include_disabled(

--- a/tests/test_substitution_extensions.py
+++ b/tests/test_substitution_extensions.py
@@ -2434,6 +2434,128 @@ def test_substitution_include_path(
     assert "Included content" in (app.outdir / "index.html").read_text()
 
 
+def test_substitution_include_content(
+    *,
+    tmp_path: Path,
+    make_app: Callable[..., SphinxTestApp],
+) -> None:
+    """Replace placeholders in included source content when requested."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "upgrade-guide.txt").write_text(
+        data=dedent(
+            text="""\
+            .. code-block:: shell
+
+               upgrade --from |SRC_VERSION| --to |NEW_VERSION|
+            """,
+        ),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+            .. |SRC_VERSION| replace:: 4.0
+            .. |NEW_VERSION| replace:: 4.1
+
+            .. include:: upgrade-guide.txt
+               :content-substitutions:
+            """,
+        ),
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        exception_on_warning=True,
+        confoverrides={"extensions": ["sphinx_substitution_extensions"]},
+    )
+    app.build()
+
+    output = app.env.get_doctree(docname="index").astext()
+    assert "upgrade --from 4.0 --to 4.1" in output
+    assert "|SRC_VERSION|" not in output
+    assert "|NEW_VERSION|" not in output
+
+
+def test_substitution_include_path_and_content(
+    *,
+    tmp_path: Path,
+    make_app: Callable[..., SphinxTestApp],
+) -> None:
+    """Replace placeholders in an include path and its source content."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "upgrade-guide.txt").write_text(
+        data=dedent(
+            text="""\
+            .. code-block:: text
+
+               Upgrade to |version|.
+            """,
+        ),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+            .. |document| replace:: upgrade-guide
+            .. |version| replace:: 4.1
+
+            .. include:: |document|.txt
+               :path-substitutions:
+               :content-substitutions:
+            """,
+        ),
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        exception_on_warning=True,
+        confoverrides={"extensions": ["sphinx_substitution_extensions"]},
+    )
+    app.build()
+
+    output = app.env.get_doctree(docname="index").astext()
+    assert "Upgrade to 4.1." in output
+    assert "|version|" not in output
+
+
+def test_substitution_include_literal_content(
+    *,
+    tmp_path: Path,
+    make_app: Callable[..., SphinxTestApp],
+) -> None:
+    """Replace placeholders when ``include`` returns a literal node."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "example.txt").write_text(
+        data="Content with |name| placeholder",
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+            .. |name| replace:: example
+
+            .. include:: example.txt
+               :literal:
+               :content-substitutions:
+            """,
+        ),
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        exception_on_warning=True,
+        confoverrides={"extensions": ["sphinx_substitution_extensions"]},
+    )
+    app.build()
+
+    output = app.env.get_doctree(docname="index").astext()
+    assert "Content with example placeholder" in output
+    assert "|name|" not in output
+
+
 def test_default_substitution_include_path(
     *,
     tmp_path: Path,
@@ -2466,6 +2588,94 @@ def test_default_substitution_include_path(
 
     assert app.statuscode == 0
     assert "Included content" in (app.outdir / "index.html").read_text()
+
+
+def test_default_substitution_include_content(
+    *,
+    tmp_path: Path,
+    make_app: Callable[..., SphinxTestApp],
+) -> None:
+    """Replace include content when substitutions are enabled by
+    default.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "example.txt").write_text(
+        data=dedent(
+            text="""\
+            Included literal content::
+
+               Content with |name| placeholder
+            """,
+        ),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+            .. |name| replace:: example
+
+            .. include:: example.txt
+            """,
+        ),
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        exception_on_warning=True,
+        confoverrides={
+            "extensions": ["sphinx_substitution_extensions"],
+            "substitutions_default_enabled": True,
+        },
+    )
+    app.build()
+
+    output = app.env.get_doctree(docname="index").astext()
+    assert "Content with example placeholder" in output
+    assert "|name|" not in output
+
+
+def test_default_substitution_include_disabled_content(
+    *,
+    tmp_path: Path,
+    make_app: Callable[..., SphinxTestApp],
+) -> None:
+    """Respect ``:nocontent-substitutions:`` when defaults are enabled."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "example.txt").write_text(
+        data=dedent(
+            text="""\
+            Included literal content::
+
+               Content with |name| placeholder
+            """,
+        ),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+            .. |name| replace:: example
+
+            .. include:: example.txt
+               :nocontent-substitutions:
+            """,
+        ),
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        exception_on_warning=True,
+        confoverrides={
+            "extensions": ["sphinx_substitution_extensions"],
+            "substitutions_default_enabled": True,
+        },
+    )
+    app.build()
+
+    output = app.env.get_doctree(docname="index").astext()
+    assert "Content with |name| placeholder" in output
 
 
 def test_default_substitution_include_disabled(


### PR DESCRIPTION
## Summary

- add `:content-substitutions:` and `:nocontent-substitutions:` to the `include` directive
- apply replacements to included source before docutils parses it, while retaining normal path, clipping, dependency, and circular-inclusion handling
- cover explicit, default-enabled, opt-out, combined path/content, and literal-node behavior
- document the feature, add a sample, and include a Towncrier news fragment

## Why

Issue #121 asks for substitution definitions from a parent reStructuredText document to be applied within an included source file, including content such as code blocks. Path substitutions were added separately, but include-level content substitutions were still missing.

## Validation

- `uv run --extra dev pytest -s -vvv --cov-fail-under 100 --cov=src/ --cov=tests .` (59 passed; 100% coverage)
- serial and parallel warning-as-error sample documentation builds
- all pre-commit, pre-push, and manual hooks

Closes #121

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The change hooks into docutils’ include parsing via `insert_input` patching, which is sensitive to parser internals but is covered by extensive tests and mirrors established `literalinclude` patterns.
> 
> **Overview**
> Adds **`:content-substitutions:`** and **`:nocontent-substitutions:`** to the custom `include` directive so parent-document substitution definitions can be applied to the text of included files before docutils parses it (e.g. placeholders inside nested `code-block` directives).
> 
> `SubstitutionInclude` now follows the same opt-in/opt-out and `substitutions_default_enabled` rules as `literalinclude` for content, while keeping existing path substitution behavior. Content replacement is done by temporarily patching `insert_input` on the state machine, then post-processing returned nodes (including `:literal:` includes).
> 
> Documentation, a sample include, doc8 ignores for the new directive options, a Towncrier fragment, and broad Sphinx integration tests cover explicit use, defaults, opt-out, combined path+content, and literal output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c1f21892d4ca7ff63255e6c28793aa36dacfc5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->