### PR TITLE
Cover nested include substitution isolation

### DIFF
--- a/src/sphinx_substitution_extensions/__init__.py
+++ b/src/sphinx_substitution_extensions/__init__.py
@@ -511,6 +511,8 @@ class SubstitutionInclude(Include):
                 source=source,
             )
 
+        # ``Include.run`` only queues these lines.  Nested includes are parsed
+        # after it returns, when this patch has already been removed.
         with patch.object(
             target=self.state_machine,
             attribute="insert_input",

--- a/tests/test_substitution_extensions.py
+++ b/tests/test_substitution_extensions.py
@@ -2498,6 +2498,69 @@ def test_substitution_include_content(
     assert content_html == expected_content_html
 
 
+def test_substitution_include_content_does_not_leak_to_nested_includes(
+    *,
+    tmp_path: Path,
+    make_app: Callable[..., SphinxTestApp],
+) -> None:
+    """Apply content substitutions only to the include that requests
+    them.
+    """
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "nested-default.txt").write_text(
+        data=dedent(
+            text="""\
+            .. code-block:: text
+
+               Default nested content with |name| placeholder
+            """,
+        ),
+    )
+    (source_directory / "nested-disabled.txt").write_text(
+        data=dedent(
+            text="""\
+            .. code-block:: text
+
+               Disabled nested content with |name| placeholder
+            """,
+        ),
+    )
+    (source_directory / "outer.txt").write_text(
+        data=dedent(
+            text="""\
+            .. include:: nested-default.txt
+
+            .. include:: nested-disabled.txt
+               :nocontent-substitutions:
+            """,
+        ),
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+            .. |name| replace:: example
+
+            .. include:: outer.txt
+               :content-substitutions:
+            """,
+        ),
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        exception_on_warning=True,
+        confoverrides={"extensions": ["sphinx_substitution_extensions"]},
+    )
+    app.build()
+
+    assert app.statuscode == 0
+    content_html = (app.outdir / "index.html").read_text()
+    assert "Default nested content with |name| placeholder" in content_html
+    assert "Disabled nested content with |name| placeholder" in content_html
+
+
 def test_substitution_include_path_and_content(
     *,
     tmp_path: Path,

--- a/tests/test_substitution_extensions.py
+++ b/tests/test_substitution_extensions.py
@@ -2527,7 +2527,8 @@ def test_substitution_include_content_does_not_leak_to_nested_includes(
             """,
         ),
     )
-    (source_directory / "outer.txt").write_text(
+    outer_file = source_directory / "outer.txt"
+    outer_file.write_text(
         data=dedent(
             text="""\
             .. include:: nested-default.txt
@@ -2537,7 +2538,8 @@ def test_substitution_include_content_does_not_leak_to_nested_includes(
             """,
         ),
     )
-    (source_directory / "index.rst").write_text(
+    source_file = source_directory / "index.rst"
+    source_file.write_text(
         data=dedent(
             text="""\
             .. |name| replace:: example
@@ -2557,8 +2559,28 @@ def test_substitution_include_content_does_not_leak_to_nested_includes(
 
     assert app.statuscode == 0
     content_html = (app.outdir / "index.html").read_text()
-    assert "Default nested content with |name| placeholder" in content_html
-    assert "Disabled nested content with |name| placeholder" in content_html
+    app.cleanup()
+
+    outer_file.write_text(
+        data=dedent(
+            text="""\
+            .. include:: nested-default.txt
+
+            .. include:: nested-disabled.txt
+            """,
+        ),
+    )
+    source_file.write_text(data=".. include:: outer.txt\n")
+
+    app_expected = make_app(
+        srcdir=source_directory,
+        exception_on_warning=True,
+    )
+    app_expected.build()
+    assert app_expected.statuscode == 0
+
+    expected_content_html = (app_expected.outdir / "index.html").read_text()
+    assert content_html == expected_content_html
 
 
 def test_substitution_include_path_and_content(


### PR DESCRIPTION
PR #1609’s post-merge review flagged a possible leak of content substitutions into nested includes. Docutils only queues included lines during `Include.run`, so nested includes are parsed after the temporary substitution hook is restored and the reported leak does not occur. This adds regression coverage for nested includes that omit `:content-substitutions:` or explicitly use `:nocontent-substitutions:`, plus an explanatory lifecycle comment beside the hook. Validation: 60 tests pass with 100% branch coverage, and all changed-file pre-commit and pre-push checks pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and comment only; include substitution behavior is unchanged.
> 
> **Overview**
> Adds regression coverage so **`:content-substitutions:`** on an outer `include` does not alter nested includes that omit that flag or use **`:nocontent-substitutions:`**. The test builds a chain (`index` → `outer.txt` → nested files) with the extension enabled, then compares HTML to a baseline build without substitution flags.
> 
> Documents why that isolation holds: in **`SubstitutionInclude`**, the temporary `insert_input` patch only wraps the direct include; docutils queues included lines and parses nested `include` directives **after** `Include.run` returns, so the hook is already gone for deeper levels. No runtime logic change—comment plus test only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 780a8a7f0268cee254864b55d4926b56460172c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->