### PR TITLE
Support substitutions in external hyperlink targets

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,6 +71,25 @@ Inline ``:substitution-code:``
 
    :substitution-download:`|author|'s manuscript <|author|_manuscript.txt>`
 
+External hyperlinks
+~~~~~~~~~~~~~~~~~~~
+
+Enable substitutions in external hyperlink targets in ``conf.py``:
+
+.. code-block:: python
+
+   """Configuration for Sphinx."""
+
+   substitutions_hyperlink_targets_enabled = True
+
+Then substitutions are applied to hyperlink targets:
+
+.. code-block:: rst
+
+   Download version |release| from the tarball_.
+
+   .. _tarball: https://example.com/releases/v|release|.tar.gz
+
 ``literalinclude``
 ~~~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -90,6 +90,23 @@ Then substitutions are applied to hyperlink targets:
 
    .. _tarball: https://example.com/releases/v|release|.tar.gz
 
+The setting enables hyperlink-target substitutions throughout the project,
+but only targets containing a defined substitution are changed. To limit a
+substitution to one page, define it in that page instead of in
+``rst_prolog``:
+
+.. code-block:: rst
+
+   .. |tarball-release| replace:: 0.8.5
+
+   Download the tarball_.
+
+   .. _tarball: https://example.com/releases/v|tarball-release|.tar.gz
+
+To limit the substitution to one link on that page, use a unique substitution
+name, such as ``tarball-release`` above, only in that link's target. Other
+hyperlink targets are left unchanged.
+
 ``literalinclude``
 ~~~~~~~~~~~~~~~~~~
 

--- a/newsfragments/178.change
+++ b/newsfragments/178.change
@@ -1,0 +1,1 @@
+Add an option to apply substitutions to external hyperlink targets.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -323,6 +323,7 @@ ignore_names = [
     "source_suffix",
     "spelling_word_list_filename",
     "substitutions_default_enabled",
+    "substitutions_hyperlink_targets_enabled",
     "templates_path",
     "warning_is_error",
 ]

--- a/src/sphinx_substitution_extensions/__init__.py
+++ b/src/sphinx_substitution_extensions/__init__.py
@@ -9,9 +9,12 @@ from docutils.nodes import (
     Element,
     Node,
     Text,
+    document,
+    reference,
     substitution_definition,
     system_message,
 )
+from docutils.nodes import target as target_node
 from docutils.parsers.rst import directives
 from docutils.parsers.rst.directives.images import Image
 from docutils.parsers.rst.directives.misc import Include
@@ -233,6 +236,38 @@ def _process_node(
             substitution_defs=substitution_defs,
             delimiter_pairs=delimiter_pairs,
         )
+
+
+@beartype
+def _substitute_hyperlink_targets(
+    app: Sphinx,
+    doctree: document,
+) -> None:
+    """Replace placeholders in hyperlink targets."""
+    if not app.config.substitutions_hyperlink_targets_enabled:
+        return
+
+    substitution_defs = _get_substitution_defs(
+        env=app.env,
+        config=app.config,
+        substitution_defs=doctree.substitution_defs,
+    )
+    delimiter_pairs = _get_delimiter_pairs(
+        env=app.env,
+        config=app.config,
+    )
+
+    for node in doctree.findall():
+        if not isinstance(node, (reference, target_node)):
+            continue
+
+        refuri = node.attributes.get("refuri")
+        if isinstance(refuri, str):
+            node["refuri"] = _apply_substitutions(
+                text=refuri,
+                substitution_defs=substitution_defs,
+                delimiter_pairs=delimiter_pairs,
+            )
 
 
 @beartype
@@ -646,6 +681,11 @@ def setup(app: Sphinx) -> ExtensionMetadata:
     """Add the custom directives to Sphinx."""
     app.add_config_value(name="substitutions", default=[], rebuild="html")
     app.add_config_value(
+        name="substitutions_hyperlink_targets_enabled",
+        default=False,
+        rebuild="html",
+    )
+    app.add_config_value(
         name="substitutions_default_enabled",
         default=False,
         rebuild="html",
@@ -671,6 +711,10 @@ def setup(app: Sphinx) -> ExtensionMetadata:
         nodeclass=addnodes.download_reference,
     )
     app.add_role(name="substitution-download", role=substitution_download_role)
+    app.connect(
+        event="doctree-read",
+        callback=_substitute_hyperlink_targets,
+    )
     return {
         "parallel_read_safe": True,
         "version": version(distribution_name="sphinx-substitution-extensions"),

--- a/tests/test_substitution_extensions.py
+++ b/tests/test_substitution_extensions.py
@@ -470,6 +470,112 @@ def test_substitution_download(
     assert content_html == expected_content_html
 
 
+def test_no_substitution_hyperlink_target(
+    *,
+    tmp_path: Path,
+    make_app: Callable[..., SphinxTestApp],
+) -> None:
+    """Leave placeholders in hyperlink targets unchanged by default."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    source_file = source_directory / "index.rst"
+    (source_directory / "conf.py").touch()
+
+    source_file.write_text(
+        data=dedent(
+            text="""\
+            .. |ver| replace:: 0.8.5
+
+            Download the tarball_
+
+            .. _tarball: https://example.com/releases/v|ver|.tar.gz
+            """,
+        ),
+    )
+    app = make_app(
+        srcdir=source_directory,
+        exception_on_warning=True,
+        confoverrides={"extensions": ["sphinx_substitution_extensions"]},
+    )
+    app.build()
+    assert app.statuscode == 0
+    content_html = (app.outdir / "index.html").read_text()
+    app.cleanup()
+
+    app_expected = make_app(
+        srcdir=source_directory,
+        exception_on_warning=True,
+    )
+    app_expected.build()
+    assert app_expected.statuscode == 0
+
+    expected_content_html = (app_expected.outdir / "index.html").read_text()
+    assert content_html == expected_content_html
+
+
+def test_substitution_hyperlink_target(
+    *,
+    tmp_path: Path,
+    make_app: Callable[..., SphinxTestApp],
+) -> None:
+    """Replace placeholders in external hyperlink targets."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    source_file = source_directory / "index.rst"
+    (source_directory / "conf.py").touch()
+
+    source_file.write_text(
+        data=dedent(
+            text="""\
+            Download the tarball_
+
+            .. _tarball: https://example.com/releases/v|ver|.tar.gz
+
+            See the `internal section`_.
+
+            Internal section
+            ----------------
+            """,
+        ),
+    )
+    app = make_app(
+        srcdir=source_directory,
+        exception_on_warning=True,
+        confoverrides={
+            "extensions": ["sphinx_substitution_extensions"],
+            "rst_prolog": ".. |ver| replace:: 0.8.5",
+            "substitutions_hyperlink_targets_enabled": True,
+        },
+    )
+    app.build()
+    assert app.statuscode == 0
+    content_html = (app.outdir / "index.html").read_text()
+    app.cleanup()
+
+    equivalent_source = dedent(
+        text="""\
+        Download the tarball_
+
+        .. _tarball: https://example.com/releases/v0.8.5.tar.gz
+
+        See the `internal section`_.
+
+        Internal section
+        ----------------
+        """,
+    )
+    source_file.write_text(data=equivalent_source)
+    app_expected = make_app(
+        srcdir=source_directory,
+        exception_on_warning=True,
+    )
+    app_expected.build()
+    assert app_expected.statuscode == 0
+
+    expected_content_html = (app_expected.outdir / "index.html").read_text()
+    assert content_html == expected_content_html
+
+
 def test_no_substitution_literal_include(
     *,
     tmp_path: Path,


### PR DESCRIPTION
Adds the opt-in `substitutions_hyperlink_targets_enabled` setting so reStructuredText substitutions can be applied inside external hyperlink targets without changing default behavior. The implementation rewrites resolved hyperlink URIs during doctree reads, documents the setting, and includes a release-note fragment. Full-HTML regression tests cover disabled and enabled behavior while ensuring internal links remain unchanged. Closes #178.

Validation: 62 tests passed with 100% coverage; pre-commit and pre-push hooks passed; the warning-as-error sample Sphinx build passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior is off by default and limited to rewriting external link URIs at build time; risk is mainly misconfigured substitution values producing wrong download URLs.
> 
> **Overview**
> Adds an **opt-in** Sphinx setting, `substitutions_hyperlink_targets_enabled` (default **off**), so reStructuredText substitutions can be expanded in **external** hyperlink target URIs—for example `.. _tarball: https://example.com/releases/v|release|.tar.gz`.
> 
> When enabled, a **`doctree-read`** handler rewrites `refuri` on `reference` and `target` nodes using the same substitution definitions and delimiters as the rest of the extension, without changing builds that leave the flag disabled. **README** documents the setting and scoping tips (page-local or link-specific substitution names), plus a **towncrier** fragment; **HTML regression tests** cover disabled vs enabled behavior and that internal cross-references stay the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1841a156d077218d0ebcf288f27a7c9f7ad4e48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->