### PR TITLE
Support MyST frontmatter substitutions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -187,6 +187,25 @@ MyST Markdown setup
 
 This will replace ``|release|`` in the new directives with ``0.1``, and ``|author|`` with ``Eleanor``.
 
+Substitutions can also be defined or overridden for an individual Markdown
+document in its frontmatter:
+
+.. code-block:: markdown
+
+   ---
+   myst:
+     substitutions:
+       release: "0.2"
+       author:
+         name: Talya
+   ---
+
+   ```{code-block} shell
+      :substitutions:
+
+      echo "|author.name| released version |release|"
+   ```
+
 Enabling substitutions by default
 ----------------------------------
 

--- a/newsfragments/1554.bugfix.rst
+++ b/newsfragments/1554.bugfix.rst
@@ -1,0 +1,1 @@
+Support MyST substitutions defined in document frontmatter.

--- a/src/sphinx_substitution_extensions/__init__.py
+++ b/src/sphinx_substitution_extensions/__init__.py
@@ -21,7 +21,9 @@ from docutils.parsers.rst.directives.misc import Include
 from docutils.parsers.rst.roles import code_role
 from docutils.parsers.rst.states import Inliner
 from docutils.statemachine import StringList
-from myst_parser.mocking import MockInliner
+from myst_parser.config.main import MdParserConfig
+from myst_parser.mdit_to_docutils.base import DocutilsRenderer
+from myst_parser.mocking import MockInliner, MockState
 from sphinx import addnodes
 from sphinx.application import Sphinx
 from sphinx.config import Config
@@ -48,6 +50,24 @@ SubstitutionValue: TypeAlias = (
     | dict[str, "SubstitutionValue"]
 )
 Substitutions: TypeAlias = dict[str, SubstitutionValue]
+
+
+@beartype
+def _get_myst_config(*, context: object) -> MdParserConfig | None:
+    """Get the effective MyST configuration from a parsing context."""
+    if isinstance(context, (MockInliner, MockState)):
+        # MyST merges front matter into a document-local configuration before
+        # it creates these parsing contexts. The Sphinx configuration only
+        # contains the global ``conf.py`` values.
+        # https://github.com/executablebooks/MyST-Parser/issues/680 tracks
+        # substitutions inside directives, but its proposed PR registers them
+        # only after directives have run:
+        # https://github.com/executablebooks/MyST-Parser/pull/966
+        renderer = vars(context)["_renderer"]
+        assert isinstance(renderer, DocutilsRenderer)
+        return renderer.md_config
+
+    return None
 
 
 @beartype
@@ -120,6 +140,7 @@ def _get_delimiter_pairs(
     *,
     env: BuildEnvironment,
     config: Config,
+    myst_config: MdParserConfig | None,
 ) -> set[tuple[str, str]]:
     """Get the delimiter pairs for substitution."""
     markdown_suffixes = {
@@ -134,7 +155,10 @@ def _get_delimiter_pairs(
     delimiter_pairs = {("|", "|")}
     parser_supported_formats = set(env.parser.supported)
     if parser_supported_formats.intersection(markdown_suffixes):
-        opening_delimiter, closing_delimiter = config.myst_sub_delimiters
+        if myst_config is None:
+            opening_delimiter, closing_delimiter = config.myst_sub_delimiters
+        else:
+            opening_delimiter, closing_delimiter = myst_config.sub_delimiters
         new_delimiter_pair = (
             opening_delimiter + opening_delimiter,
             closing_delimiter + closing_delimiter,
@@ -150,6 +174,7 @@ def _get_substitution_defs(
     env: BuildEnvironment,
     config: Config,
     substitution_defs: dict[str, substitution_definition],
+    myst_config: MdParserConfig | None,
 ) -> dict[str, str]:
     """Get the substitution definitions from the environment."""
     markdown_suffixes = {
@@ -160,9 +185,16 @@ def _get_substitution_defs(
 
     parser_supported_formats = set(env.parser.supported)
     if parser_supported_formats.intersection(markdown_suffixes):
-        if "substitution" in config.myst_enable_extensions:
+        if myst_config is None:
+            enable_extensions = config.myst_enable_extensions
+            substitutions = dict(config.myst_substitutions)
+        else:
+            enable_extensions = myst_config.enable_extensions
+            substitutions = dict(myst_config.substitutions)
+
+        if "substitution" in enable_extensions:
             return _flatten_substitutions(
-                substitutions=dict(config.myst_substitutions),
+                substitutions=substitutions,
             )
     else:
         return {
@@ -251,10 +283,12 @@ def _substitute_hyperlink_targets(
         env=app.env,
         config=app.config,
         substitution_defs=doctree.substitution_defs,
+        myst_config=None,
     )
     delimiter_pairs = _get_delimiter_pairs(
         env=app.env,
         config=app.config,
+        myst_config=None,
     )
 
     for node in doctree.findall():
@@ -284,15 +318,18 @@ class SubstitutionCodeBlock(CodeBlock):
         """Replace placeholders with given variables."""
         new_content = StringList()
         existing_content = self.content
+        myst_config = _get_myst_config(context=self.state)
         substitution_defs = _get_substitution_defs(
             env=self.env,
             config=self.config,
             substitution_defs=self.state.document.substitution_defs,
+            myst_config=myst_config,
         )
 
         delimiter_pairs = _get_delimiter_pairs(
             env=self.env,
             config=self.config,
+            myst_config=myst_config,
         )
 
         should_apply_substitutions = _should_apply_substitutions(
@@ -341,15 +378,18 @@ class SubstitutionCodeRole:
         """Replace placeholders with given variables."""
         settings = inliner.document.settings
         env = settings.env
+        myst_config = _get_myst_config(context=inliner)
         substitution_defs = _get_substitution_defs(
             env=env,
             config=env.config,
             substitution_defs=inliner.document.substitution_defs,
+            myst_config=myst_config,
         )
 
         delimiter_pairs = _get_delimiter_pairs(
             env=env,
             config=env.config,
+            myst_config=myst_config,
         )
 
         text = _apply_substitutions(
@@ -406,6 +446,7 @@ class SubstitutionLiteralInclude(LiteralInclude):
         and/or
         included file content.
         """
+        myst_config = _get_myst_config(context=self.state)
         should_apply_path_substitutions = _should_apply_substitutions(
             options=self.options,
             config=self.config,
@@ -418,11 +459,13 @@ class SubstitutionLiteralInclude(LiteralInclude):
                 env=self.env,
                 config=self.config,
                 substitution_defs=self.state.document.substitution_defs,
+                myst_config=myst_config,
             )
 
             delimiter_pairs = _get_delimiter_pairs(
                 env=self.env,
                 config=self.config,
+                myst_config=myst_config,
             )
 
             for argument_index, argument in enumerate(iterable=self.arguments):
@@ -446,11 +489,13 @@ class SubstitutionLiteralInclude(LiteralInclude):
                 env=self.env,
                 config=self.config,
                 substitution_defs=self.state.document.substitution_defs,
+                myst_config=myst_config,
             )
 
             delimiter_pairs = _get_delimiter_pairs(
                 env=self.env,
                 config=self.config,
+                myst_config=myst_config,
             )
 
             for node in nodes_list:
@@ -486,6 +531,7 @@ class SubstitutionInclude(Include):
             return list(super().run())
 
         config = env.config
+        myst_config = _get_myst_config(context=self.state)
         should_apply_path_substitutions = _should_apply_substitutions(
             options=self.options,
             config=config,
@@ -509,10 +555,12 @@ class SubstitutionInclude(Include):
             env=env,
             config=config,
             substitution_defs=self.state.document.substitution_defs,
+            myst_config=myst_config,
         )
         delimiter_pairs = _get_delimiter_pairs(
             env=env,
             config=config,
+            myst_config=myst_config,
         )
 
         if should_apply_path_substitutions:
@@ -582,6 +630,7 @@ class SubstitutionImage(Image):
         """Replace placeholders with given variables in the image path."""
         env = self.state.document.settings.env
         config = env.config
+        myst_config = _get_myst_config(context=self.state)
 
         should_apply_path_substitutions = _should_apply_substitutions(
             options=self.options,
@@ -595,11 +644,13 @@ class SubstitutionImage(Image):
                 env=env,
                 config=config,
                 substitution_defs=self.state.document.substitution_defs,
+                myst_config=myst_config,
             )
 
             delimiter_pairs = _get_delimiter_pairs(
                 env=env,
                 config=config,
+                myst_config=myst_config,
             )
 
             for argument_index, argument in enumerate(iterable=self.arguments):
@@ -643,15 +694,18 @@ class SubstitutionXRefRole(XRefRole):
         variables.
         """
         assert isinstance(env, BuildEnvironment)
+        myst_config = _get_myst_config(context=self.inliner)
         substitution_defs = _get_substitution_defs(
             env=env,
             config=env.config,
             substitution_defs=self.inliner.document.substitution_defs,
+            myst_config=myst_config,
         )
 
         delimiter_pairs = _get_delimiter_pairs(
             env=env,
             config=env.config,
+            myst_config=myst_config,
         )
 
         title = _apply_substitutions(

--- a/tests/test_substitution_extensions.py
+++ b/tests/test_substitution_extensions.py
@@ -576,6 +576,70 @@ def test_substitution_hyperlink_target(
     assert content_html == expected_content_html
 
 
+def test_myst_substitution_hyperlink_target(
+    *,
+    tmp_path: Path,
+    make_app: Callable[..., SphinxTestApp],
+) -> None:
+    """Replace global MyST substitutions in external hyperlink targets."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    source_file = source_directory / "index.md"
+    (source_directory / "conf.py").touch()
+    source_file.write_text(
+        data=dedent(
+            text="""\
+            ```{eval-rst}
+            Download the tarball_
+
+            .. _tarball: https://example.com/releases/v|ver|.tar.gz
+            ```
+            """,
+        ),
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        exception_on_warning=True,
+        confoverrides={
+            "extensions": [
+                "myst_parser",
+                "sphinx_substitution_extensions",
+            ],
+            "myst_enable_extensions": ["substitution"],
+            "myst_substitutions": {"ver": "0.8.5"},
+            "substitutions_hyperlink_targets_enabled": True,
+        },
+    )
+    app.build()
+    assert app.statuscode == 0
+    content_html = (app.outdir / "index.html").read_text()
+    app.cleanup()
+
+    source_file.write_text(
+        data=dedent(
+            text="""\
+            ```{eval-rst}
+            Download the tarball_
+
+            .. _tarball: https://example.com/releases/v0.8.5.tar.gz
+            ```
+            """,
+        ),
+    )
+    app_expected = make_app(
+        srcdir=source_directory,
+        exception_on_warning=True,
+        freshenv=True,
+        confoverrides={"extensions": ["myst_parser"]},
+    )
+    app_expected.build()
+    assert app_expected.statuscode == 0
+    expected_content_html = (app_expected.outdir / "index.html").read_text()
+
+    assert content_html == expected_content_html
+
+
 def test_no_substitution_literal_include(
     *,
     tmp_path: Path,
@@ -1494,6 +1558,95 @@ class TestMyst:
         expected_content_html = (
             app_expected.outdir / "markdown_document.html"
         ).read_text()
+        assert content_html == expected_content_html
+
+    @staticmethod
+    def test_myst_frontmatter_substitutions(
+        *,
+        tmp_path: Path,
+        make_app: Callable[..., SphinxTestApp],
+    ) -> None:
+        """MyST front matter substitutions are respected in code
+        blocks.
+        """
+        source_directory = tmp_path / "source"
+        source_directory.mkdir()
+        index_source_file = source_directory / "index.rst"
+        markdown_source_file = source_directory / "markdown_document.md"
+        (source_directory / "conf.py").touch()
+        index_source_file.write_text(
+            data=dedent(
+                text="""\
+                .. toctree::
+
+                   markdown_document
+                """,
+            ),
+        )
+        markdown_source_file.write_text(
+            data=dedent(
+                text="""\
+                ---
+                myst:
+                  substitutions:
+                    local:
+                      nested: local_value
+                ---
+
+                # Title
+
+                ```{code-block} shell
+                :substitutions:
+
+                $ PRE-|global|-|local.nested|-POST
+                ```
+                """,
+            ),
+        )
+
+        app = make_app(
+            srcdir=source_directory,
+            exception_on_warning=True,
+            confoverrides={
+                "extensions": [
+                    "myst_parser",
+                    "sphinx_substitution_extensions",
+                ],
+                "myst_enable_extensions": ["substitution"],
+                "myst_substitutions": {
+                    "global": "global_value",
+                },
+            },
+        )
+        app.build()
+        assert app.statuscode == 0
+        content_html = (app.outdir / "markdown_document.html").read_text()
+        app.cleanup()
+
+        markdown_source_file.write_text(
+            data=dedent(
+                text="""\
+                # Title
+
+                ```{code-block} shell
+
+                $ PRE-global_value-local_value-POST
+                ```
+                """,
+            ),
+        )
+        app_expected = make_app(
+            srcdir=source_directory,
+            exception_on_warning=True,
+            freshenv=True,
+            confoverrides={"extensions": ["myst_parser"]},
+        )
+        app_expected.build()
+        assert app_expected.statuscode == 0
+        expected_content_html = (
+            app_expected.outdir / "markdown_document.html"
+        ).read_text()
+
         assert content_html == expected_content_html
 
     @staticmethod


### PR DESCRIPTION
## Summary

MyST merges frontmatter into a document-local renderer configuration, while the extension previously read only global Sphinx configuration.
This change uses the effective MyST configuration when processing directives and roles, while retaining the global fallback used during doctree processing.
It adds regression coverage, user documentation, and a news fragment for nested frontmatter substitutions, closing #1554.

## Validation

`uv run --extra=dev pytest -q --cov-fail-under 100 --cov=src/ --cov=tests .` (64 passed, 100% coverage), plus commit and pre-push hooks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the substitution source for all MyST directive/role parsing and relies on MyST internal renderer access, but behavior is gated to MyST contexts with explicit global fallback and strong test coverage.
> 
> **Overview**
> MyST substitution handling in directives and roles now uses each document’s **effective** MyST config (including frontmatter `myst.substitutions` and per-document delimiters) instead of only global `conf.py` values.
> 
> A new `_get_myst_config` reads `MdParserConfig` from MyST’s `MockInliner` / `MockState` renderer when parsing Markdown; `_get_substitution_defs` and `_get_delimiter_pairs` take an optional `myst_config` and fall back to Sphinx config when it is absent (e.g. doctree-wide hyperlink target substitution). **code-block**, **literalinclude**, **include**, **image**, and substitution roles are wired through this path.
> 
> README documents per-page frontmatter overrides; tests cover nested frontmatter substitutions in code blocks and global MyST substitutions in eval-rst hyperlink targets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a674c8f6db9ac84d3539c420b921819b8319257. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->