### PR TITLE
Run shfmt through uv

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -134,7 +134,7 @@ repos:
 
       - id: shfmt
         name: shfmt
-        entry: shfmt --write --space-redirects --indent=4
+        entry: uv run --extra=dev shfmt --write --space-redirects --indent=4
         language: python
         types_or: [shell]
         additional_dependencies:


### PR DESCRIPTION
## What changed

- Run the `shfmt` pre-commit hook through `uv run --extra=dev`.

## Why

The project already pins `shfmt-py` in its development dependencies. Invoking `shfmt` directly made this hook inconsistent with the other project-tool hooks and allowed an ambient executable to be used instead of the pinned development environment.

## Impact

The hook now uses the project-pinned `shfmt` version. Formatting behavior and arguments are unchanged.

## Validation

- `uv run --extra=dev shfmt --version`
- `uv run --extra=dev prek run shfmt --all-files`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single pre-commit entry change with no formatting flag changes; only affects which shfmt binary runs locally/CI when the hook is not skipped.
> 
> **Overview**
> The **`shfmt`** pre-commit hook now invokes **`uv run --extra=dev shfmt`** instead of calling a bare **`shfmt`** executable on **`PATH`**.
> 
> **`shfmt`** flags (`--write`, `--space-redirects`, `--indent=4`) are unchanged. This matches hooks like **`shellcheck`** and ensures the hook uses the **`shfmt-py`** version pinned in dev dependencies rather than an ambient install.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f48c75360c9e557a6719f7c1d6bcc0b34f3bfbfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->