### PR TITLE
Add no-defaults linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -369,3 +369,9 @@ repos:
         types_or: [markdown, rst]
         additional_dependencies:
           - *uv_version
+
+  - repo: https://github.com/adamtheturtle/no-defaults
+    rev: v1.0.0
+    hooks:
+      - id: no-defaults
+        stages: [pre-commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -286,6 +286,16 @@ repos:
         stages: [pre-commit]
         require_serial: true
 
+      - id: no-defaults
+        name: no-defaults
+        entry: uv run --extra=dev no-defaults
+        language: python
+        types_or: [python]
+        additional_dependencies:
+          - *uv_version
+        stages: [pre-commit]
+        require_serial: true
+
       - id: doc8
         name: doc8
         entry: uv run --extra=dev -m doc8
@@ -369,9 +379,3 @@ repos:
         types_or: [markdown, rst]
         additional_dependencies:
           - *uv_version
-
-  - repo: https://github.com/adamtheturtle/no-defaults
-    rev: v1.0.1
-    hooks:
-      - id: no-defaults
-        stages: [pre-commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -371,7 +371,7 @@ repos:
           - *uv_version
 
   - repo: https://github.com/adamtheturtle/no-defaults
-    rev: v1.0.0
+    rev: v1.0.1
     hooks:
       - id: no-defaults
         stages: [pre-commit]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ optional-dependencies.dev = [
     "interrogate==1.7.0",
     "mypy[faster-cache]==2.3.0",
     "mypy-strict-kwargs==2026.7.19.1",
+    "no-defaults==1.0.1",
     "prek==0.4.11",
     "pydocstringformatter==1.0.0",
     "pylint[spelling]==4.0.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,6 +134,7 @@ lint.per-file-ignores."doccmd_*.py" = [
 lint.unfixable = [
     "ERA001",
 ]
+lint.external = [ "NOD" ]
 lint.flake8-tidy-imports.banned-api."typing.cast".msg = "typing.cast is banned: use explicit type narrowing or a typed variable instead."
 lint.pydocstyle.convention = "google"
 
@@ -416,3 +417,7 @@ ignore_path = [
 [tool.yamlfix]
 section_whitelines = 1
 whitelines = 1
+
+[tool.no_defaults]
+private_only = true
+per_file_enforcement."tests/**" = "all"


### PR DESCRIPTION
Add `no-defaults` v1.0.0 to the pre-commit/prek configuration.

The policy rejects defaults everywhere in `tests/**` and for private functions, classes, and modules elsewhere. Existing defaults are behavior-preservingly baselined with targeted `# noqa: NOD001` comments where necessary; Ruff is configured to recognize the external `NOD` rule family. Vendored Typeshed is excluded where applicable.

Validated with `prek validate-config`, `prek run no-defaults --all-files`, and Ruff checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only lint and CI configuration; no changes to runtime library behavior or public APIs.
> 
> **Overview**
> Adds **`no-defaults` v1.0.1** to the dev toolchain and wires it into pre-commit alongside existing checks like `strict-kwargs`.
> 
> Policy is configured in **`pyproject.toml`**: private functions/classes/modules must not use parameter defaults in production code, while **`tests/**`** enforces **no defaults anywhere**. Ruff is told to load the external **`NOD`** rule family via `lint.external`, so `# noqa: NOD001` suppressions stay consistent with the checker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 671b9705ce2dcabb8b63ab94f06ea1b015d99f31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->