### PR TITLE
Bump beartype to 0.23.0rc0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dynamic = [
     "version",
 ]
 dependencies = [
-    "beartype>=0.22.9",
+    "beartype==0.23.0rc0",
     "docutils>=0.19",
     "myst-parser>=4.0.0",
     "sphinx>=8.1.0",


### PR DESCRIPTION
Tests the [beartype 0.23.0rc0](https://pypi.org/project/beartype/0.23.0rc0/) release candidate against this repository's test suite.

Pins `beartype` to the release candidate in `pyproject.toml` and updates `uv.lock` to match.

Not intended to merge as-is — the pin should be relaxed once the release candidate has been evaluated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single dependency version pin for RC testing with no application logic changes; revert or relax the pin before release.
> 
> **Overview**
> Pins the runtime **`beartype`** dependency from **`>=0.22.9`** to **`==0.23.0rc0`** so CI and local installs exercise the [0.23.0 release candidate](https://pypi.org/project/beartype/0.23.0rc0/) against this repo’s test suite (including **`pytest-beartype-tests`**).
> 
> This is a **temporary evaluation pin**, not meant to merge as-is—the constraint should be relaxed once the RC is validated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebe1bedac7e69150f8cf37d487e832abc7d207b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->