### PR TITLE
Configure mypy to respect gitignore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -340,6 +340,7 @@ max_supported_python = "3.14"
 [tool.mypy]
 files = [ "." ]
 exclude = [ "build" ]
+exclude_gitignore = true
 follow_untyped_imports = true
 strict = true
 plugins = [


### PR DESCRIPTION
## Summary

- configure mypy with `exclude_gitignore = true`
- prevent files ignored by Git from being included in mypy discovery

## Impact

Mypy will respect the project's `.gitignore` rules when discovering files. This avoids type-checking generated, local, or otherwise ignored files.

## Validation

- formatted and parsed `pyproject.toml` with `pyproject-fmt`
- verified the branch diff is exactly one added line in `pyproject.toml`
- ran Git whitespace validation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line tooling config change with no runtime, security, or application logic impact.
> 
> **Overview**
> Configures mypy with `exclude_gitignore = true` so files ignored by Git are skipped during type-check discovery.
> 
> This avoids type-checking generated, local, or otherwise gitignored files when mypy scans from `files = ["."]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36d40884d71195087ff6e5bdde5def788b131dd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->