### PR TITLE
Preserve Sphinx included-file tracking

### DIFF
--- a/newsfragments/1632.bugfix.rst
+++ b/newsfragments/1632.bugfix.rst
@@ -1,0 +1,1 @@
+Preserve Sphinx's tracking of files consumed by the ``include`` directive.

--- a/src/sphinx_substitution_extensions/__init__.py
+++ b/src/sphinx_substitution_extensions/__init__.py
@@ -17,7 +17,6 @@ from docutils.nodes import (
 from docutils.nodes import target as target_node
 from docutils.parsers.rst import directives
 from docutils.parsers.rst.directives.images import Image
-from docutils.parsers.rst.directives.misc import Include
 from docutils.parsers.rst.roles import code_role
 from docutils.parsers.rst.states import Inliner
 from docutils.statemachine import StringList
@@ -28,6 +27,7 @@ from sphinx import addnodes
 from sphinx.application import Sphinx
 from sphinx.config import Config
 from sphinx.directives.code import CodeBlock, LiteralInclude
+from sphinx.directives.other import Include
 from sphinx.environment import BuildEnvironment
 from sphinx.errors import SphinxError
 from sphinx.roles import XRefRole

--- a/src/sphinx_substitution_extensions/__init__.py
+++ b/src/sphinx_substitution_extensions/__init__.py
@@ -17,6 +17,7 @@ from docutils.nodes import (
 from docutils.nodes import target as target_node
 from docutils.parsers.rst import directives
 from docutils.parsers.rst.directives.images import Image
+from docutils.parsers.rst.directives.misc import Include as DocutilsInclude
 from docutils.parsers.rst.roles import code_role
 from docutils.parsers.rst.states import Inliner
 from docutils.statemachine import StringList
@@ -528,7 +529,7 @@ class SubstitutionInclude(Include):
         env = self.state.document.settings.env
 
         if env is None:
-            return list(super().run())
+            return list(DocutilsInclude.run(self=self))
 
         config = env.config
         myst_config = _get_myst_config(context=self.state)

--- a/tests/test_substitution_extensions.py
+++ b/tests/test_substitution_extensions.py
@@ -2641,6 +2641,30 @@ def test_no_substitution_include(
     assert "Included content" in (app.outdir / "index.html").read_text()
 
 
+def test_include_fragment_is_not_reported_as_unreferenced(
+    *,
+    tmp_path: Path,
+    make_app: Callable[..., SphinxTestApp],
+) -> None:
+    """Register included documents with the Sphinx environment."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "fragment.rst").write_text(data="Included content")
+    (source_directory / "index.rst").write_text(
+        data=".. include:: fragment.rst\n",
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        exception_on_warning=True,
+        confoverrides={"extensions": ["sphinx_substitution_extensions"]},
+    )
+    app.build()
+
+    assert app.statuscode == 0
+
+
 def test_include_without_sphinx_environment(tmp_path: Path) -> None:
     """Support documents which have no Sphinx environment."""
     source_file = tmp_path / "index.rst"


### PR DESCRIPTION
## What changed

- Base `SubstitutionInclude` on Sphinx's `Include` directive.
- Add a regression test proving include-only fragments are registered and do not trigger `toc.not_included` warnings.
- Add a bug-fix news fragment.

## Why

The override inherited directly from docutils, bypassing Sphinx's `env.note_included()` call. Include-only `.rst` fragments were therefore treated as orphaned documents and broke warning-as-error builds.

## Validation

- `pytest -q tests/test_substitution_extensions.py -k 'include_fragment_is_not_reported_as_unreferenced or substitution_include'`
- Repository pre-commit and pre-push checks

Closes #1632.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow directive inheritance change with a focused regression test; substitution behavior on the Sphinx path is unchanged aside from proper include registration.
> 
> **Overview**
> **`SubstitutionInclude`** now subclasses Sphinx’s **`Include`** (`sphinx.directives.other`) instead of docutils’ include directive, so Sphinx’s **`env.note_included()`** behavior runs for normal builds and include-only fragments are no longer treated as orphaned documents (avoiding **`toc.not_included`** under warning-as-error).
> 
> When there is no Sphinx environment, the no-env path explicitly delegates to docutils **`DocutilsInclude.run`**. A regression test builds a project that only **`.. include::`**s a fragment with **`exception_on_warning=True`**, plus a bugfix news fragment for #1632.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbe896edddb6600d03449a48a9777b3a112ebc94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->