### PR TITLE
Restore source-relative include paths

### DIFF
--- a/newsfragments/1633.bugfix.rst
+++ b/newsfragments/1633.bugfix.rst
@@ -1,0 +1,2 @@
+Restore Sphinx's source-directory-relative handling of slash-prefixed
+``include`` paths.

--- a/tests/test_substitution_extensions.py
+++ b/tests/test_substitution_extensions.py
@@ -2717,6 +2717,46 @@ def test_substitution_include_path(
     assert "Included content" in (app.outdir / "index.html").read_text()
 
 
+@pytest.mark.parametrize(
+    argnames=("include_path", "options"),
+    argvalues=[
+        ("/fragments/example.txt", ""),
+        ("/fragments/|name|.txt", "   :path-substitutions:\n"),
+    ],
+)
+def test_include_path_is_relative_to_source_directory(
+    *,
+    tmp_path: Path,
+    make_app: Callable[..., SphinxTestApp],
+    include_path: str,
+    options: str,
+) -> None:
+    """Resolve slash-prefixed include paths from Sphinx's source root."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    fragments_directory = source_directory / "fragments"
+    fragments_directory.mkdir()
+    (fragments_directory / "example.txt").write_text(data="Included content")
+    (source_directory / "index.rst").write_text(
+        data=(
+            ".. |name| replace:: example\n\n"
+            f".. include:: {include_path}\n"
+            f"{options}"
+        ),
+    )
+
+    app = make_app(
+        srcdir=source_directory,
+        exception_on_warning=True,
+        confoverrides={"extensions": ["sphinx_substitution_extensions"]},
+    )
+    app.build()
+
+    assert app.statuscode == 0
+    assert "Included content" in (app.outdir / "index.html").read_text()
+
+
 def test_substitution_include_content(
     *,
     tmp_path: Path,

--- a/tests/test_substitution_extensions.py
+++ b/tests/test_substitution_extensions.py
@@ -2738,7 +2738,8 @@ def test_include_path_is_relative_to_source_directory(
     fragments_directory = source_directory / "fragments"
     fragments_directory.mkdir()
     (fragments_directory / "example.txt").write_text(data="Included content")
-    (source_directory / "index.rst").write_text(
+    source_file = source_directory / "index.rst"
+    source_file.write_text(
         data=(
             ".. |name| replace:: example\n\n"
             f".. include:: {include_path}\n"
@@ -2754,7 +2755,19 @@ def test_include_path_is_relative_to_source_directory(
     app.build()
 
     assert app.statuscode == 0
-    assert "Included content" in (app.outdir / "index.html").read_text()
+    content_html = (app.outdir / "index.html").read_text()
+    app.cleanup()
+
+    source_file.write_text(data=".. include:: /fragments/example.txt\n")
+    app_expected = make_app(
+        srcdir=source_directory,
+        exception_on_warning=True,
+    )
+    app_expected.build()
+    assert app_expected.statuscode == 0
+
+    expected_content_html = (app_expected.outdir / "index.html").read_text()
+    assert content_html == expected_content_html
 
 
 def test_substitution_include_content(


### PR DESCRIPTION
## What changed

- Base `SubstitutionInclude` on Sphinx's `Include` directive.
- Test slash-prefixed paths both with and without path substitutions.
- Add a bug-fix news fragment.

## Why

The docutils base class treated `/fragments/...` as a filesystem-root path. Sphinx's directive resolves this documented form relative to the project source directory, and it must receive the path after substitutions are applied.

## Validation

- `pytest -q tests/test_substitution_extensions.py -k 'include_path_is_relative_to_source_directory or substitution_include'`
- Repository pre-commit and pre-push checks

Closes #1633.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted include path resolution fix with regression tests; no auth, security, or broad API surface changes.
> 
> **Overview**
> Fixes **#1633** by aligning `SubstitutionInclude` with Sphinx’s `include` behavior so paths like `/fragments/example.txt` resolve from the **project source directory**, not the filesystem root (after any `:path-substitutions:` expansion).
> 
> Adds a parametrized integration test that builds with the substitution extension and asserts the HTML matches a plain Sphinx `.. include:: /fragments/example.txt` build, covering both a static slash path and `/fragments/|name|.txt` with `:path-substitutions:`. Documents the fix in `newsfragments/1633.bugfix.rst`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 643ba5cd05baf06c7b91249a03e8fe9fcfaab09e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->