### PR TITLE
Restore Sphinx's include-read event

### DIFF
--- a/newsfragments/1634.bugfix.rst
+++ b/newsfragments/1634.bugfix.rst
@@ -1,0 +1,2 @@
+Restore Sphinx's ``include-read`` event for the ``include`` directive and
+compose listener changes with content substitutions.

--- a/src/sphinx_substitution_extensions/__init__.py
+++ b/src/sphinx_substitution_extensions/__init__.py
@@ -525,6 +525,38 @@ class SubstitutionInclude(Include):
         NO_PATH_SUBSTITUTION_OPTION_NAME: directives.flag,
     }
 
+    def _run_with_include_read(
+        self,
+        *,
+        env: BuildEnvironment,
+        substitution_defs: dict[str, str],
+        delimiter_pairs: set[tuple[str, str]],
+    ) -> list[Node]:
+        """Apply substitutions after existing include-read listeners."""
+
+        def substitute_include_content(
+            _app: Sphinx,
+            _relative_path: Path,
+            _parent_docname: str,
+            content: list[str],
+        ) -> None:
+            """Substitute content changed by earlier listeners."""
+            content[0] = _apply_substitutions(
+                text=content[0],
+                substitution_defs=substitution_defs,
+                delimiter_pairs=delimiter_pairs,
+            )
+
+        listener_id = env.events.connect(
+            name="include-read",
+            callback=substitute_include_content,
+            priority=999,
+        )
+        try:
+            return list(super().run())
+        finally:
+            env.events.disconnect(listener_id=listener_id)
+
     def run(self) -> list[Node]:
         """Replace placeholders in the path and/or included content."""
         env = self.state.document.settings.env
@@ -577,29 +609,11 @@ class SubstitutionInclude(Include):
             return list(super().run())
 
         if env.events.listeners.get("include-read"):
-
-            def substitute_include_content(
-                _app: Sphinx,
-                _relative_path: Path,
-                _parent_docname: str,
-                content: list[str],
-            ) -> None:
-                """Substitute after existing include-read listeners."""
-                content[0] = _apply_substitutions(
-                    text=content[0],
-                    substitution_defs=substitution_defs,
-                    delimiter_pairs=delimiter_pairs,
-                )
-
-            listener_id = env.events.connect(
-                "include-read",
-                substitute_include_content,
-                priority=999,
+            return self._run_with_include_read(
+                env=env,
+                substitution_defs=substitution_defs,
+                delimiter_pairs=delimiter_pairs,
             )
-            try:
-                return list(super().run())
-            finally:
-                env.events.disconnect(listener_id)
 
         original_insert_input = self.state_machine.insert_input
 

--- a/src/sphinx_substitution_extensions/__init__.py
+++ b/src/sphinx_substitution_extensions/__init__.py
@@ -1,6 +1,7 @@
 """Custom Sphinx extensions."""
 
 from importlib.metadata import version
+from pathlib import Path
 from typing import Any, ClassVar, TypeAlias
 from unittest.mock import patch
 
@@ -574,6 +575,31 @@ class SubstitutionInclude(Include):
 
         if not should_apply_content_substitutions:
             return list(super().run())
+
+        if env.events.listeners.get("include-read"):
+
+            def substitute_include_content(
+                _app: Sphinx,
+                _relative_path: Path,
+                _parent_docname: str,
+                content: list[str],
+            ) -> None:
+                """Substitute after existing include-read listeners."""
+                content[0] = _apply_substitutions(
+                    text=content[0],
+                    substitution_defs=substitution_defs,
+                    delimiter_pairs=delimiter_pairs,
+                )
+
+            listener_id = env.events.connect(
+                "include-read",
+                substitute_include_content,
+                priority=999,
+            )
+            try:
+                return list(super().run())
+            finally:
+                env.events.disconnect(listener_id)
 
         original_insert_input = self.state_machine.insert_input
 

--- a/tests/test_substitution_extensions.py
+++ b/tests/test_substitution_extensions.py
@@ -2844,10 +2844,12 @@ def test_include_read_event_with_content_substitutions(
     source_directory = tmp_path / "source"
     source_directory.mkdir()
     (source_directory / "conf.py").touch()
-    (source_directory / "example.txt").write_text(
+    include_file = source_directory / "example.txt"
+    include_file.write_text(
         data="Included |name| content",
     )
-    (source_directory / "index.rst").write_text(
+    source_file = source_directory / "index.rst"
+    source_file.write_text(
         data=dedent(
             text="""\
             .. |name| replace:: original
@@ -2878,9 +2880,20 @@ def test_include_read_event_with_content_substitutions(
     app.build()
 
     assert observed_content == ["Included |name| content"]
-    assert (
-        "Observed original content" in (app.outdir / "index.html").read_text()
+    content_html = (app.outdir / "index.html").read_text()
+    app.cleanup()
+
+    include_file.write_text(data="Observed original content")
+    source_file.write_text(data=".. include:: example.txt\n")
+    app_expected = make_app(
+        srcdir=source_directory,
+        exception_on_warning=True,
     )
+    app_expected.build()
+    assert app_expected.statuscode == 0
+
+    expected_content_html = (app_expected.outdir / "index.html").read_text()
+    assert content_html == expected_content_html
 
 
 def test_substitution_include_content_does_not_leak_to_nested_includes(

--- a/tests/test_substitution_extensions.py
+++ b/tests/test_substitution_extensions.py
@@ -8,6 +8,7 @@ from textwrap import dedent
 import pytest
 from docutils import core, nodes
 from docutils.parsers.rst import directives
+from sphinx.application import Sphinx
 from sphinx.errors import SphinxError
 from sphinx.testing.util import SphinxTestApp
 
@@ -2832,6 +2833,54 @@ def test_substitution_include_content(
 
     expected_content_html = (app_expected.outdir / "index.html").read_text()
     assert content_html == expected_content_html
+
+
+def test_include_read_event_with_content_substitutions(
+    *,
+    tmp_path: Path,
+    make_app: Callable[..., SphinxTestApp],
+) -> None:
+    """Emit include-read and then substitute the listener's content."""
+    source_directory = tmp_path / "source"
+    source_directory.mkdir()
+    (source_directory / "conf.py").touch()
+    (source_directory / "example.txt").write_text(
+        data="Included |name| content",
+    )
+    (source_directory / "index.rst").write_text(
+        data=dedent(
+            text="""\
+            .. |name| replace:: original
+
+            .. include:: example.txt
+               :content-substitutions:
+            """,
+        ),
+    )
+    observed_content: list[str] = []
+
+    def on_include_read(
+        _app: Sphinx,
+        _relative_path: Path,
+        _parent_docname: str,
+        content: list[str],
+    ) -> None:
+        """Record and transform the included source."""
+        observed_content.append(content[0])
+        content[0] = content[0].replace("Included", "Observed")
+
+    app = make_app(
+        srcdir=source_directory,
+        exception_on_warning=True,
+        confoverrides={"extensions": ["sphinx_substitution_extensions"]},
+    )
+    app.connect(event="include-read", callback=on_include_read)
+    app.build()
+
+    assert observed_content == ["Included |name| content"]
+    assert (
+        "Observed original content" in (app.outdir / "index.html").read_text()
+    )
 
 
 def test_substitution_include_content_does_not_leak_to_nested_includes(


### PR DESCRIPTION
## What changed

- Base `SubstitutionInclude` on Sphinx's `Include` directive so `include-read` is emitted.
- Compose `include-read` listener transformations with content substitutions.
- Pin the ordering: existing listeners observe the original source, their changes are retained, and substitutions run afterward before parsing.
- Add a bug-fix news fragment.

## Why

The docutils base class never emits Sphinx's `include-read` event. A base-class change alone also lets Sphinx replace the state-machine hook, which would skip this extension's content substitutions whenever a listener is registered. The explicit event composition preserves both behaviors.

## Validation

- `pytest -q tests/test_substitution_extensions.py -k 'include_read_event_with_content_substitutions or substitution_include'`
- `ruff check src/sphinx_substitution_extensions/__init__.py tests/test_substitution_extensions.py`
- Repository pre-commit and pre-push checks

Closes #1634.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes include directive ordering when both `include-read` and content substitutions are active; scoped to that path with a regression test.
> 
> **Overview**
> **Restores Sphinx `include-read` for `.. include::` with `:content-substitutions:`** while keeping placeholder expansion working alongside other extensions that hook the same event.
> 
> When any `include-read` listeners are registered, `SubstitutionInclude` delegates to Sphinx’s `Include.run()` and registers a temporary listener at **priority 999** so existing handlers run first on the raw included text, their in-place edits are kept, and **content substitutions run last** before parsing. If no listeners exist, behavior stays on the prior `insert_input` patch path.
> 
> Adds **`test_include_read_event_with_content_substitutions`** and a **news fragment** for #1634.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 092b987982f13d451a1f1168f61f265275de7d28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->