### PR TITLE
Use the pyrefly strict preset

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -351,6 +351,7 @@ plugins = [
 
 [tool.pyrefly]
 errors.non-exhaustive-match = "error"
+errors.unused-ignore = "error"
 
 [tool.pyright]
 typeCheckingMode = "strict"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "docutils>=0.19",
     "myst-parser>=4.0.0",
     "sphinx>=8.1.0",
+    "typing-extensions>=4.4.0",
 ]
 optional-dependencies.dev = [
     "actionlint-py==1.7.12.24",
@@ -351,7 +352,7 @@ plugins = [
 
 [tool.pyrefly]
 errors.non-exhaustive-match = "error"
-errors.unused-ignore = "error"
+preset = "strict"
 
 [tool.pyright]
 typeCheckingMode = "strict"

--- a/src/sphinx_substitution_extensions/__init__.py
+++ b/src/sphinx_substitution_extensions/__init__.py
@@ -34,6 +34,7 @@ from sphinx.environment import BuildEnvironment
 from sphinx.errors import SphinxError
 from sphinx.roles import XRefRole
 from sphinx.util.typing import ExtensionMetadata, OptionSpec
+from typing_extensions import override
 
 from sphinx_substitution_extensions.shared import (
     CONTENT_SUBSTITUTION_OPTION_NAME,
@@ -332,6 +333,7 @@ class SubstitutionCodeBlock(CodeBlock):
     option_spec[SUBSTITUTION_OPTION_NAME] = directives.flag
     option_spec[NO_SUBSTITUTION_OPTION_NAME] = directives.flag
 
+    @override
     def run(self) -> list[Node]:
         """Replace placeholders with given variables."""
         new_content = StringList()
@@ -458,6 +460,7 @@ class SubstitutionLiteralInclude(LiteralInclude):
     option_spec[NO_CONTENT_SUBSTITUTION_OPTION_NAME] = directives.flag
     option_spec[NO_PATH_SUBSTITUTION_OPTION_NAME] = directives.flag
 
+    @override
     def run(self) -> list[Node]:
         """
         Replace placeholders with given variables in the file path
@@ -598,6 +601,7 @@ class SubstitutionInclude(Include):
 
         return nodes_list
 
+    @override
     def run(self) -> list[Node]:
         """Replace placeholders in the path and/or included content."""
         env = self.state.document.settings.env
@@ -710,6 +714,7 @@ class SubstitutionImage(Image):
         NO_PATH_SUBSTITUTION_OPTION_NAME: directives.flag,
     }
 
+    @override
     def run(self) -> list[Node]:
         """Replace placeholders with given variables in the image path."""
         env = self.state.document.settings.env
@@ -751,6 +756,7 @@ class SubstitutionImage(Image):
 class SubstitutionXRefRole(XRefRole):
     """Custom role for XRefs."""
 
+    @override
     def create_xref_node(self) -> tuple[list[Node], list[system_message]]:
         """Override parent method to set classes.
 
@@ -763,13 +769,12 @@ class SubstitutionXRefRole(XRefRole):
 
         return super().create_xref_node()
 
+    @override
     def process_link(
         self,
         env: BuildEnvironment,
         refnode: Element,
-        # We allow a boolean-typed positional argument as we are matching the
-        # method signature of the parent class.
-        has_explicit_title: bool,  # noqa: FBT001
+        has_explicit_title: bool,
         title: str,
         target: str,
     ) -> tuple[str, str]:


### PR DESCRIPTION
Switches the pyrefly config to `preset = "strict"` (see https://pyrefly.org/en/docs/configuration/). Strict enables `unused-ignore`, so stale `# pyrefly: ignore` comments fail the check, along with `implicit-any`, `missing-override-decorator` and others. Any new errors from the stricter checks are fixed in this PR. Same change as VWS-Python/vws-python-mock#3567.

This project supports Python versions before 3.12, where \`typing.override\` does not exist, so \`typing-extensions\` is added as a runtime dependency to provide the \`@override\` decorator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)