### PR TITLE
Use PEP 735 dependency groups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,21 +40,21 @@ jobs:
 
       - name: Build sample
         run: |
-          uv run --extra=dev sphinx-build -W -b html sample/source sample/build
+          uv run --group=dev sphinx-build -W -b html sample/source sample/build
         env:
           UV_PYTHON: ${{ matrix.python-version }}
           UV_RESOLUTION: ${{ matrix.uv-resolution }}
 
       - name: Build sample parallel
         run: |
-          uv run --extra=dev sphinx-build -j 2 -W -b html sample/source sample/build
+          uv run --group=dev sphinx-build -j 2 -W -b html sample/source sample/build
         env:
           UV_PYTHON: ${{ matrix.python-version }}
           UV_RESOLUTION: ${{ matrix.uv-resolution }}
 
       - name: Run tests
         run: |
-          uv run --extra=dev pytest -s -vvv --cov-fail-under 100 --cov=src/ --cov=tests .
+          uv run --group=dev pytest -s -vvv --cov-fail-under 100 --cov=src/ --cov=tests .
         env:
           UV_PYTHON: ${{ matrix.python-version }}
           UV_RESOLUTION: ${{ matrix.uv-resolution }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Generate the GitHub release notes
         env:
           RELEASE: ${{ steps.calver.outputs.release }}
-        run: uv run --extra=release towncrier build --draft --version "$RELEASE" >
+        run: uv run --group=release towncrier build --draft --version "$RELEASE" >
           release-notes.md
 
       # Assemble the same fragments into CHANGELOG.rst under a new
@@ -61,7 +61,7 @@ jobs:
       - name: Update the changelog
         env:
           RELEASE: ${{ steps.calver.outputs.release }}
-        run: uv run --extra=release towncrier build --yes --version "$RELEASE"
+        run: uv run --group=release towncrier build --yes --version "$RELEASE"
 
       - uses: stefanzweifel/git-auto-commit-action@v7
         id: commit
@@ -95,7 +95,7 @@ jobs:
           git fetch --tags
           git checkout "$NEW_TAG"
           uv build --sdist --wheel --out-dir dist/
-          uv run --extra=release check-wheel-contents dist/*.whl
+          uv run --group=release check-wheel-contents dist/*.whl
 
       # We use PyPI trusted publishing rather than a PyPI API token.
       # See https://github.com/pypa/gh-action-pypi-publish/tree/release/v1/?tab=readme-ov-file#trusted-publishing.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -12,7 +12,7 @@ Install Python dependencies in a virtual environment.
 
 .. code-block:: shell
 
-   pip install --editable '.[dev]'
+   pip install --editable . --group dev
 
 Spell checking requires ``enchant``.
 This can be installed on macOS, for example, with `Homebrew`_:

--- a/prek.toml
+++ b/prek.toml
@@ -104,7 +104,7 @@ hooks = [
   {
     id = "actionlint",
     name = "actionlint",
-    entry = "uv run --extra=dev actionlint",
+    entry = "uv run --group=dev actionlint",
     language = "python",
     pass_filenames = false,
     types_or = ["yaml"],
@@ -114,7 +114,7 @@ hooks = [
   {
     id = "pydocstringformatter",
     name = "pydocstringformatter",
-    entry = "uv run --extra=dev pydocstringformatter",
+    entry = "uv run --group=dev pydocstringformatter",
     language = "python",
     types_or = ["python"],
     additional_dependencies = ["uv==0.11.7"],
@@ -123,7 +123,7 @@ hooks = [
   {
     id = "shellcheck",
     name = "shellcheck",
-    entry = "uv run --extra=dev shellcheck --shell=bash",
+    entry = "uv run --group=dev shellcheck --shell=bash",
     language = "python",
     types_or = ["shell"],
     additional_dependencies = ["uv==0.11.7"],
@@ -132,7 +132,7 @@ hooks = [
   {
     id = "shellcheck-docs",
     name = "shellcheck-docs",
-    entry = 'uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=shell --language=console --command="shellcheck --shell=bash"',
+    entry = 'uv run --group=dev doccmd --no-write-to-file --example-workers 0 --language=shell --language=console --command="shellcheck --shell=bash"',
     language = "python",
     types_or = [
       "markdown",
@@ -144,7 +144,7 @@ hooks = [
   {
     id = "shfmt",
     name = "shfmt",
-    entry = "uv run --extra=dev shfmt --write --space-redirects --indent=4",
+    entry = "uv run --group=dev shfmt --write --space-redirects --indent=4",
     language = "python",
     types_or = ["shell"],
     additional_dependencies = ["uv==0.11.7"],
@@ -153,7 +153,7 @@ hooks = [
   {
     id = "shfmt-docs",
     name = "shfmt-docs",
-    entry = 'uv run --extra=dev doccmd --language=shell --language=console --skip-marker=shfmt --no-pad-file --command="shfmt --write --space-redirects --indent=4"',
+    entry = 'uv run --group=dev doccmd --language=shell --language=console --skip-marker=shfmt --no-pad-file --command="shfmt --write --space-redirects --indent=4"',
     language = "python",
     types_or = [
       "markdown",
@@ -166,7 +166,7 @@ hooks = [
     id = "mypy",
     name = "mypy",
     stages = ["pre-push"],
-    entry = "uv run --extra=dev -m mypy --num-workers=4",
+    entry = "uv run --group=dev -m mypy --num-workers=4",
     language = "python",
     types_or = [
       "python",
@@ -179,7 +179,7 @@ hooks = [
     id = "mypy-docs",
     name = "mypy-docs",
     stages = ["pre-push"],
-    entry = 'uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy --num-workers=4"',
+    entry = 'uv run --group=dev doccmd --no-write-to-file --language=python --command="mypy --num-workers=4"',
     language = "python",
     types_or = [
       "markdown",
@@ -190,7 +190,7 @@ hooks = [
     id = "check-manifest",
     name = "check-manifest",
     stages = ["pre-push"],
-    entry = "uv run --extra=dev -m check_manifest",
+    entry = "uv run --group=dev -m check_manifest",
     language = "python",
     pass_filenames = false,
     additional_dependencies = ["uv==0.11.7"]
@@ -199,7 +199,7 @@ hooks = [
     id = "pyright",
     name = "pyright",
     stages = ["pre-push"],
-    entry = "uv run --extra=dev -m pyright .",
+    entry = "uv run --group=dev -m pyright .",
     language = "python",
     types_or = [
       "python",
@@ -212,7 +212,7 @@ hooks = [
     id = "pyright-docs",
     name = "pyright-docs",
     stages = ["pre-push"],
-    entry = 'uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python --command="pyright"',
+    entry = 'uv run --group=dev doccmd --no-write-to-file --example-workers 0 --language=python --command="pyright"',
     language = "python",
     types_or = [
       "markdown",
@@ -223,7 +223,7 @@ hooks = [
     id = "pyright-verifytypes",
     name = "pyright-verifytypes",
     stages = ["pre-push"],
-    entry = "uv run --extra=dev -m pyright --ignoreexternal --verifytypes sphinx_substitution_extensions",
+    entry = "uv run --group=dev -m pyright --ignoreexternal --verifytypes sphinx_substitution_extensions",
     language = "python",
     pass_filenames = false,
     types_or = ["python"],
@@ -233,7 +233,7 @@ hooks = [
     id = "ty",
     name = "ty",
     stages = ["pre-push"],
-    entry = "uv run --extra=dev ty check",
+    entry = "uv run --group=dev ty check",
     language = "python",
     types_or = [
       "python",
@@ -246,7 +246,7 @@ hooks = [
     id = "ty-docs",
     name = "ty-docs",
     stages = ["pre-push"],
-    entry = 'uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python --command="ty check"',
+    entry = 'uv run --group=dev doccmd --no-write-to-file --example-workers 0 --language=python --command="ty check"',
     language = "python",
     types_or = [
       "markdown",
@@ -257,7 +257,7 @@ hooks = [
   {
     id = "vulture",
     name = "vulture",
-    entry = "uv run --extra=dev -m vulture .",
+    entry = "uv run --group=dev -m vulture .",
     language = "python",
     types_or = ["python"],
     pass_filenames = false,
@@ -267,7 +267,7 @@ hooks = [
   {
     id = "vulture-docs",
     name = "vulture docs",
-    entry = 'uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python --command="vulture"',
+    entry = 'uv run --group=dev doccmd --no-write-to-file --example-workers 0 --language=python --command="vulture"',
     language = "python",
     types_or = [
       "markdown",
@@ -279,7 +279,7 @@ hooks = [
   {
     id = "pyroma",
     name = "pyroma",
-    entry = "uv run --extra=dev -m pyroma --min 10 .",
+    entry = "uv run --group=dev -m pyroma --min 10 .",
     language = "python",
     pass_filenames = false,
     types_or = ["toml"],
@@ -289,7 +289,7 @@ hooks = [
   {
     id = "deptry",
     name = "deptry",
-    entry = "uv run --extra=dev -m deptry src/",
+    entry = "uv run --group=dev -m deptry src/",
     language = "python",
     pass_filenames = false,
     additional_dependencies = ["uv==0.11.7"],
@@ -298,7 +298,7 @@ hooks = [
   {
     id = "pylint",
     name = "pylint",
-    entry = "uv run --extra=dev -m pylint src/ tests/",
+    entry = "uv run --group=dev -m pylint src/ tests/",
     language = "python",
     stages = ["manual"],
     pass_filenames = false,
@@ -307,7 +307,7 @@ hooks = [
   {
     id = "ruff-check-fix",
     name = "Ruff check fix",
-    entry = "uv run --extra=dev -m ruff check --fix",
+    entry = "uv run --group=dev -m ruff check --fix",
     language = "python",
     types_or = ["python"],
     additional_dependencies = ["uv==0.11.7"],
@@ -316,7 +316,7 @@ hooks = [
   {
     id = "ruff-check-fix-docs",
     name = "Ruff check fix docs",
-    entry = 'uv run --extra=dev doccmd --language=python --command="ruff check --fix"',
+    entry = 'uv run --group=dev doccmd --language=python --command="ruff check --fix"',
     language = "python",
     types_or = [
       "markdown",
@@ -328,7 +328,7 @@ hooks = [
   {
     id = "ruff-format-fix",
     name = "Ruff format",
-    entry = "uv run --extra=dev -m ruff format",
+    entry = "uv run --group=dev -m ruff format",
     language = "python",
     types_or = ["python"],
     additional_dependencies = ["uv==0.11.7"],
@@ -337,7 +337,7 @@ hooks = [
   {
     id = "ruff-format-fix-docs",
     name = "Ruff format docs",
-    entry = 'uv run --extra=dev doccmd --language=python --no-pad-file --command="ruff format"',
+    entry = 'uv run --group=dev doccmd --language=python --no-pad-file --command="ruff format"',
     language = "python",
     types_or = [
       "markdown",
@@ -349,7 +349,7 @@ hooks = [
   {
     id = "strict-kwargs-fix",
     name = "strict-kwargs",
-    entry = "uv run --extra=dev strict-kwargs check --diff",
+    entry = "uv run --group=dev strict-kwargs check --diff",
     language = "python",
     types_or = ["python"],
     additional_dependencies = ["uv==0.11.7"],
@@ -359,7 +359,7 @@ hooks = [
   {
     id = "no-defaults",
     name = "no-defaults",
-    entry = "uv run --extra=dev no-defaults",
+    entry = "uv run --group=dev no-defaults",
     language = "python",
     types_or = ["python"],
     additional_dependencies = ["uv==0.11.7"],
@@ -369,7 +369,7 @@ hooks = [
   {
     id = "vale-sync",
     name = "vale sync",
-    entry = "uv run --extra=dev vale sync",
+    entry = "uv run --group=dev vale sync",
     language = "python",
     pass_filenames = false,
     files = '(\.(rst|md)$|^\.vale\.ini$)',
@@ -379,7 +379,7 @@ hooks = [
   {
     id = "vale",
     name = "vale",
-    entry = "uv run --extra=dev vale",
+    entry = "uv run --group=dev vale",
     language = "python",
     types_or = [
       "rst",
@@ -392,7 +392,7 @@ hooks = [
   {
     id = "doc8",
     name = "doc8",
-    entry = "uv run --extra=dev -m doc8",
+    entry = "uv run --group=dev -m doc8",
     language = "python",
     types_or = ["rst"],
     additional_dependencies = ["uv==0.11.7"],
@@ -401,7 +401,7 @@ hooks = [
   {
     id = "interrogate",
     name = "interrogate",
-    entry = "uv run --extra=dev -m interrogate",
+    entry = "uv run --group=dev -m interrogate",
     language = "python",
     types_or = ["python"],
     additional_dependencies = ["uv==0.11.7"],
@@ -410,7 +410,7 @@ hooks = [
   {
     id = "interrogate-docs",
     name = "interrogate docs",
-    entry = 'uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python --command="interrogate"',
+    entry = 'uv run --group=dev doccmd --no-write-to-file --example-workers 0 --language=python --command="interrogate"',
     language = "python",
     types_or = [
       "markdown",
@@ -422,7 +422,7 @@ hooks = [
   {
     id = "pyproject-fmt-fix",
     name = "pyproject-fmt",
-    entry = "uv run --extra=dev pyproject-fmt",
+    entry = "uv run --group=dev pyproject-fmt",
     language = "python",
     types_or = ["toml"],
     files = "pyproject.toml",
@@ -431,7 +431,7 @@ hooks = [
   {
     id = "yamlfix",
     name = "yamlfix",
-    entry = "uv run --extra=dev yamlfix",
+    entry = "uv run --group=dev yamlfix",
     language = "python",
     types_or = ["yaml"],
     additional_dependencies = ["uv==0.11.7"],
@@ -440,7 +440,7 @@ hooks = [
   {
     id = "zizmor",
     name = "zizmor",
-    entry = "uv run --extra=dev zizmor --strict-collection .github",
+    entry = "uv run --group=dev zizmor --strict-collection .github",
     language = "python",
     pass_filenames = false,
     types_or = ["yaml"],
@@ -450,7 +450,7 @@ hooks = [
   {
     id = "sphinx-lint",
     name = "sphinx-lint",
-    entry = "uv run --extra=dev sphinx-lint --enable=all --disable=line-too-long",
+    entry = "uv run --group=dev sphinx-lint --enable=all --disable=line-too-long",
     language = "python",
     types_or = ["rst"],
     additional_dependencies = ["uv==0.11.7"],
@@ -460,7 +460,7 @@ hooks = [
     id = "pyrefly",
     name = "pyrefly",
     stages = ["pre-push"],
-    entry = "uv run --extra=dev pyrefly check",
+    entry = "uv run --group=dev pyrefly check",
     language = "python",
     types_or = [
       "python",
@@ -473,7 +473,7 @@ hooks = [
     id = "pyrefly-docs",
     name = "pyrefly-docs",
     stages = ["pre-push"],
-    entry = 'uv run --extra=dev doccmd --no-write-to-file --example-workers 0 --language=python --command="pyrefly check"',
+    entry = 'uv run --group=dev doccmd --no-write-to-file --example-workers 0 --language=python --command="pyrefly check"',
     language = "python",
     types_or = [
       "markdown",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,10 @@ dependencies = [
     "sphinx>=8.1.0",
     "typing-extensions>=4.4.0",
 ]
-optional-dependencies.dev = [
+urls.Source = "https://github.com/adamtheturtle/sphinx-substitution-extensions"
+
+[dependency-groups]
+dev = [
     "actionlint-py==1.7.12.24",
     "check-manifest==0.51",
     "deptry==0.25.1",
@@ -80,11 +83,7 @@ optional-dependencies.dev = [
     "yamlfix==1.19.1",
     "zizmor==1.30.0",
 ]
-optional-dependencies.release = [ "check-wheel-contents==0.6.3", "towncrier==25.8.0" ]
-urls.Source = "https://github.com/adamtheturtle/sphinx-substitution-extensions"
-
-[dependency-groups]
-dev = []
+release = [ "check-wheel-contents==0.6.3", "towncrier==25.8.0" ]
 
 [tool.setuptools]
 packages.find.where = [
@@ -283,12 +282,6 @@ ignore = [
     "tests-pylintrc",
     "tests/**",
     "zizmor.yml",
-]
-
-[tool.deptry]
-optional_dependencies_dev_groups = [
-    "dev",
-    "release",
 ]
 
 [tool.vulture]


### PR DESCRIPTION
## Summary

- move development and release tooling from published extras to PEP 735 dependency groups
- update CI, release, contributor, and hook commands to select groups
- regenerate `uv.lock` where the repository commits one
- preserve genuine runtime/user-facing extras

This keeps development tooling out of package metadata and gives Dependabot and uv one dependency representation to update.

## Validation

- repository hooks pass
- `uv lock --check` passes where applicable
