### PR TITLE
Enable all Pyrefly errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -352,7 +352,7 @@ plugins = [
 
 [tool.pyrefly]
 errors.non-exhaustive-match = "error"
-preset = "strict"
+preset = "all"
 
 [tool.pyright]
 typeCheckingMode = "strict"

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -7,6 +7,7 @@ inline
 linters
 pragma
 py
+pyrefly
 pyright
 pytest
 reportUnknownArgumentType

--- a/src/sphinx_substitution_extensions/__init__.py
+++ b/src/sphinx_substitution_extensions/__init__.py
@@ -115,20 +115,22 @@ def _flatten_substitutions(
     result: dict[str, str] = {}
     stack: list[tuple[str, SubstitutionValue]] = [("", substitutions)]
 
-    while stack:
+    while len(stack) > 0:
         current_key, current_value = stack.pop()
 
         match current_value:
             case dict():
                 for key, value in current_value.items():
                     _validate_substitution_key(key=key)
-                    new_key = f"{current_key}.{key}" if current_key else key
+                    new_key = (
+                        f"{current_key}.{key}" if current_key != "" else key
+                    )
                     stack.append((new_key, value))
             case list():
                 for idx, item in enumerate(iterable=current_value):
                     new_key = (
                         f"{current_key}.{idx}"
-                        if current_key
+                        if current_key != ""
                         else str(object=idx)
                     )
                     stack.append((new_key, item))
@@ -157,7 +159,7 @@ def _get_delimiter_pairs(
     # originally shipped with.
     delimiter_pairs = {("|", "|")}
     parser_supported_formats = set(env.parser.supported)
-    if parser_supported_formats.intersection(markdown_suffixes):
+    if len(parser_supported_formats.intersection(markdown_suffixes)) > 0:
         if myst_config is None:
             opening_delimiter, closing_delimiter = config.myst_sub_delimiters
         else:
@@ -187,7 +189,7 @@ def _get_substitution_defs(
     }
 
     parser_supported_formats = set(env.parser.supported)
-    if parser_supported_formats.intersection(markdown_suffixes):
+    if len(parser_supported_formats.intersection(markdown_suffixes)) > 0:
         if myst_config is None:
             enable_extensions = config.myst_enable_extensions
             substitutions = dict(config.myst_substitutions)
@@ -229,7 +231,7 @@ def _apply_substitutions(
 @beartype
 def _should_apply_substitutions(
     *,
-    options: dict[str, Any],
+    options: dict[str, object],
     config: Config,
     yes_flag: str,
     no_flag: str,
@@ -327,8 +329,8 @@ def _substitute_hyperlink_targets(
 class SubstitutionCodeBlock(CodeBlock):
     """Similar to CodeBlock but replaces placeholders with variables."""
 
-    option_spec: ClassVar[OptionSpec] = (
-        CodeBlock.option_spec.copy() if CodeBlock.option_spec else {}
+    option_spec: ClassVar[OptionSpec] = (  # pyrefly: ignore [explicit-any]
+        CodeBlock.option_spec.copy()
     )
     option_spec[SUBSTITUTION_OPTION_NAME] = directives.flag
     option_spec[NO_SUBSTITUTION_OPTION_NAME] = directives.flag
@@ -378,7 +380,7 @@ class SubstitutionCodeBlock(CodeBlock):
 class SubstitutionCodeRole:
     """Custom role for substitution code."""
 
-    options: ClassVar[dict[str, Any]] = {
+    options: ClassVar[dict[str, object]] = {
         "class": directives.class_option,
         "language": directives.unchanged,
     }
@@ -392,12 +394,12 @@ class SubstitutionCodeRole:
         inliner: Inliner | MockInliner,
         *,
         # We allow mutable defaults as the Sphinx implementation requires it.
-        options: dict[Any, Any] = {},  # noqa: B006
+        options: dict[Any, Any] = {},  # noqa: B006  # pyrefly: ignore [explicit-any]
         content: list[str] = [],  # noqa: B006
     ) -> tuple[list[Node], list[system_message]]:
         """Replace placeholders with given variables."""
         settings = inliner.document.settings
-        env = settings.env
+        env: BuildEnvironment = settings.env
         myst_config = _get_myst_config(context=inliner)
         substitution_defs = _get_substitution_defs(
             env=env,
@@ -452,8 +454,8 @@ class SubstitutionLiteralInclude(LiteralInclude):
     variables.
     """
 
-    option_spec: ClassVar[OptionSpec] = (
-        LiteralInclude.option_spec.copy() if LiteralInclude.option_spec else {}
+    option_spec: ClassVar[OptionSpec] = (  # pyrefly: ignore [explicit-any]
+        LiteralInclude.option_spec.copy()
     )
     option_spec[CONTENT_SUBSTITUTION_OPTION_NAME] = directives.flag
     option_spec[PATH_SUBSTITUTION_OPTION_NAME] = directives.flag
@@ -538,8 +540,8 @@ class SubstitutionInclude(Include):
     path.
     """
 
-    option_spec: ClassVar[OptionSpec | None] = {
-        **(Include.option_spec or {}),
+    option_spec: ClassVar[OptionSpec | None] = {  # pyrefly: ignore [explicit-any]
+        **(Include.option_spec if Include.option_spec is not None else {}),
         CONTENT_SUBSTITUTION_OPTION_NAME: directives.flag,
         PATH_SUBSTITUTION_OPTION_NAME: directives.flag,
         NO_CONTENT_SUBSTITUTION_OPTION_NAME: directives.flag,
@@ -604,12 +606,12 @@ class SubstitutionInclude(Include):
     @override
     def run(self) -> list[Node]:
         """Replace placeholders in the path and/or included content."""
-        env = self.state.document.settings.env
+        env: BuildEnvironment | None = self.state.document.settings.env
 
         if env is None:
             return list(DocutilsInclude.run(self=self))
 
-        config = env.config
+        config: Config = env.config
         myst_config = _get_myst_config(context=self.state)
         should_apply_path_substitutions = _should_apply_substitutions(
             options=self.options,
@@ -644,8 +646,9 @@ class SubstitutionInclude(Include):
 
         if should_apply_path_substitutions:
             for argument_index, argument in enumerate(iterable=self.arguments):
+                argument_text: str = argument
                 self.arguments[argument_index] = _apply_substitutions(
-                    text=argument,
+                    text=argument_text,
                     substitution_defs=substitution_defs,
                     delimiter_pairs=delimiter_pairs,
                 )
@@ -653,7 +656,7 @@ class SubstitutionInclude(Include):
         if not should_apply_content_substitutions:
             return list(super().run())
 
-        if env.events.listeners.get("include-read"):
+        if "include-read" in env.events.listeners:
             return self._run_with_include_read(
                 env=env,
                 substitution_defs=substitution_defs,
@@ -708,8 +711,8 @@ class SubstitutionImage(Image):
     path.
     """
 
-    option_spec: ClassVar[OptionSpec | None] = {
-        **(Image.option_spec or {}),
+    option_spec: ClassVar[OptionSpec | None] = {  # pyrefly: ignore [explicit-any]
+        **(Image.option_spec if Image.option_spec is not None else {}),
         PATH_SUBSTITUTION_OPTION_NAME: directives.flag,
         NO_PATH_SUBSTITUTION_OPTION_NAME: directives.flag,
     }
@@ -717,8 +720,8 @@ class SubstitutionImage(Image):
     @override
     def run(self) -> list[Node]:
         """Replace placeholders with given variables in the image path."""
-        env = self.state.document.settings.env
-        config = env.config
+        env: BuildEnvironment = self.state.document.settings.env
+        config: Config = env.config
         myst_config = _get_myst_config(context=self.state)
 
         should_apply_path_substitutions = _should_apply_substitutions(
@@ -743,8 +746,9 @@ class SubstitutionImage(Image):
             )
 
             for argument_index, argument in enumerate(iterable=self.arguments):
+                argument_text: str = argument
                 self.arguments[argument_index] = _apply_substitutions(
-                    text=argument,
+                    text=argument_text,
                     substitution_defs=substitution_defs,
                     delimiter_pairs=delimiter_pairs,
                 )
@@ -854,7 +858,7 @@ def setup(app: Sphinx) -> ExtensionMetadata:
         nodeclass=addnodes.download_reference,
     )
     app.add_role(name="substitution-download", role=substitution_download_role)
-    app.connect(
+    _ = app.connect(
         event="doctree-read",
         callback=_substitute_hyperlink_targets,
     )

--- a/tests/test_equivalence_cases.py
+++ b/tests/test_equivalence_cases.py
@@ -34,12 +34,16 @@ class Case:
     expected: Build
 
 
-def _as_untyped_dict(value: dict[Any, Any]) -> dict[Any, Any]:
+def _as_untyped_dict(
+    value: dict[Any, Any],  # pyrefly: ignore [explicit-any]
+) -> dict[Any, Any]:  # pyrefly: ignore [explicit-any]
     """Expose a parser mapping through its intentionally loose type."""
     return value
 
 
-def _as_untyped_list(value: list[Any]) -> list[Any]:
+def _as_untyped_list(
+    value: list[Any],  # pyrefly: ignore [explicit-any]
+) -> list[Any]:  # pyrefly: ignore [explicit-any]
     """Expose a parser-produced list through its intentionally loose
     type.
     """
@@ -82,7 +86,7 @@ def _string_mapping(value: object, *, context: str) -> dict[str, str]:
 
 def _check_keys(data: dict[str, object], *, context: str) -> None:
     """Reject unknown keys left after parsing a table."""
-    if data:  # pragma: no cover
+    if len(data) > 0:  # pragma: no cover
         unknown_keys = ", ".join(sorted(data))
         msg = f"Unknown keys in {context}: {unknown_keys}"
         raise ValueError(msg)
@@ -186,7 +190,7 @@ def _destination(*, source_directory: Path, relative_path: str) -> Path:
 def _write_build(*, source_directory: Path, build: Build) -> None:
     """Materialize one build's files."""
     overlap = build.files.keys() & build.binary_files.keys()
-    if overlap:  # pragma: no cover
+    if len(overlap) > 0:  # pragma: no cover
         msg = f"Files cannot be both text and binary: {sorted(overlap)}"
         raise ValueError(msg)
     for relative_path, content in build.files.items():
@@ -195,14 +199,14 @@ def _write_build(*, source_directory: Path, build: Build) -> None:
             relative_path=relative_path,
         )
         destination.parent.mkdir(parents=True, exist_ok=True)
-        destination.write_text(data=content)
+        _ = destination.write_text(data=content)
     for relative_path, content in build.binary_files.items():
         destination = _destination(
             source_directory=source_directory,
             relative_path=relative_path,
         )
         destination.parent.mkdir(parents=True, exist_ok=True)
-        destination.write_bytes(
+        _ = destination.write_bytes(
             data=base64.b64decode(s=content, validate=True),
         )
 

--- a/tests/test_substitution_extensions.py
+++ b/tests/test_substitution_extensions.py
@@ -48,7 +48,7 @@ def test_substitution_literal_include_in_rest_example(
     (source_directory / "conf.py").touch()
 
     include_file = source_directory / "example.txt"
-    include_file.write_text(data="Content with |a| placeholder")
+    _ = include_file.write_text(data="Content with |a| placeholder")
 
     source_file_content = dedent(
         text="""\
@@ -60,7 +60,7 @@ def test_substitution_literal_include_in_rest_example(
               :content-substitutions:
         """,
     )
-    source_file.write_text(data=source_file_content)
+    _ = source_file.write_text(data=source_file_content)
     app = make_app(
         srcdir=source_directory,
         warningiserror=True,
@@ -116,8 +116,8 @@ class TestMyst:
             ```
             """,
         )
-        index_source_file.write_text(data=index_source_file_content)
-        markdown_source_file.write_text(data=markdown_source_file_content)
+        _ = index_source_file.write_text(data=index_source_file_content)
+        _ = markdown_source_file.write_text(data=markdown_source_file_content)
 
         app = make_app(
             srcdir=source_directory,
@@ -178,8 +178,8 @@ class TestMyst:
             ```
             """,
         )
-        index_source_file.write_text(data=index_source_file_content)
-        markdown_source_file.write_text(data=markdown_source_file_content)
+        _ = index_source_file.write_text(data=index_source_file_content)
+        _ = markdown_source_file.write_text(data=markdown_source_file_content)
 
         app = make_app(
             srcdir=source_directory,
@@ -235,8 +235,8 @@ class TestMyst:
             ```
             """,
         )
-        index_source_file.write_text(data=index_source_file_content)
-        markdown_source_file.write_text(data=markdown_source_file_content)
+        _ = index_source_file.write_text(data=index_source_file_content)
+        _ = markdown_source_file.write_text(data=markdown_source_file_content)
 
         app = make_app(
             srcdir=source_directory,
@@ -271,8 +271,8 @@ def test_no_substitution_include(
     source_directory = tmp_path / "source"
     source_directory.mkdir()
     (source_directory / "conf.py").touch()
-    (source_directory / "example.txt").write_text(data="Included content")
-    (source_directory / "index.rst").write_text(
+    _ = (source_directory / "example.txt").write_text(data="Included content")
+    _ = (source_directory / "index.rst").write_text(
         data=".. include:: example.txt\n",
     )
 
@@ -296,8 +296,8 @@ def test_include_fragment_is_not_reported_as_unreferenced(
     source_directory = tmp_path / "source"
     source_directory.mkdir()
     (source_directory / "conf.py").touch()
-    (source_directory / "fragment.rst").write_text(data="Included content")
-    (source_directory / "index.rst").write_text(
+    _ = (source_directory / "fragment.rst").write_text(data="Included content")
+    _ = (source_directory / "index.rst").write_text(
         data=".. include:: fragment.rst\n",
     )
 
@@ -314,8 +314,8 @@ def test_include_fragment_is_not_reported_as_unreferenced(
 def test_include_without_sphinx_environment(tmp_path: Path) -> None:
     """Support documents which have no Sphinx environment."""
     source_file = tmp_path / "index.rst"
-    source_file.write_text(data=".. include:: included.rst\n")
-    (tmp_path / "included.rst").write_text(data="Included content")
+    _ = source_file.write_text(data=".. include:: included.rst\n")
+    _ = (tmp_path / "included.rst").write_text(data="Included content")
     directives.register_directive(
         name="include",
         directive=sphinx_substitution_extensions.SubstitutionInclude,
@@ -340,8 +340,8 @@ def test_substitution_include_path(
     source_directory = tmp_path / "source"
     source_directory.mkdir()
     (source_directory / "conf.py").touch()
-    (source_directory / "example.txt").write_text(data="Included content")
-    (source_directory / "index.rst").write_text(
+    _ = (source_directory / "example.txt").write_text(data="Included content")
+    _ = (source_directory / "index.rst").write_text(
         data=dedent(
             text="""\
             .. |name| replace:: example
@@ -373,11 +373,11 @@ def test_include_read_event_with_content_substitutions(
     source_directory.mkdir()
     (source_directory / "conf.py").touch()
     include_file = source_directory / "example.txt"
-    include_file.write_text(
+    _ = include_file.write_text(
         data="Included |name| content",
     )
     source_file = source_directory / "index.rst"
-    source_file.write_text(
+    _ = source_file.write_text(
         data=dedent(
             text="""\
             .. |name| replace:: original
@@ -404,15 +404,15 @@ def test_include_read_event_with_content_substitutions(
         exception_on_warning=True,
         confoverrides={"extensions": ["sphinx_substitution_extensions"]},
     )
-    app.connect(event="include-read", callback=on_include_read)
+    _ = app.connect(event="include-read", callback=on_include_read)
     app.build()
 
     assert observed_content == ["Included |name| content"]
     content_html = (app.outdir / "index.html").read_text()
     app.cleanup()
 
-    include_file.write_text(data="Observed original content")
-    source_file.write_text(data=".. include:: example.txt\n")
+    _ = include_file.write_text(data="Observed original content")
+    _ = source_file.write_text(data=".. include:: example.txt\n")
     app_expected = make_app(
         srcdir=source_directory,
         exception_on_warning=True,
@@ -433,8 +433,8 @@ def test_default_substitution_include_path(
     source_directory = tmp_path / "source"
     source_directory.mkdir()
     (source_directory / "conf.py").touch()
-    (source_directory / "example.txt").write_text(data="Included content")
-    (source_directory / "index.rst").write_text(
+    _ = (source_directory / "example.txt").write_text(data="Included content")
+    _ = (source_directory / "index.rst").write_text(
         data=dedent(
             text="""\
             .. |name| replace:: example
@@ -467,8 +467,8 @@ def test_default_substitution_include_disabled(
     source_directory = tmp_path / "source"
     source_directory.mkdir()
     (source_directory / "conf.py").touch()
-    (source_directory / "[[name]].txt").write_text(data="Included content")
-    (source_directory / "index.rst").write_text(
+    _ = (source_directory / "[[name]].txt").write_text(data="Included content")
+    _ = (source_directory / "index.rst").write_text(
         data=dedent(
             text="""\
             .. toctree::
@@ -477,7 +477,7 @@ def test_default_substitution_include_disabled(
             """,
         ),
     )
-    (source_directory / "document.md").write_text(
+    _ = (source_directory / "document.md").write_text(
         data=dedent(
             text="""\
             # Document


### PR DESCRIPTION
Switch Pyrefly from the strict preset to the all preset and fix the newly enabled diagnostics.

The changes make ignored results and truthiness checks explicit and type the Sphinx environment boundaries while retaining narrow suppressions for upstream Any-based interfaces.

Validated locally with all prek stages and 72 tests.