### PR TITLE
Use Ty's strictest recommended configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,7 @@ line-length = 79
 lint.select = [
     "ALL",
 ]
+lint.extend-select = [ "ANN", "PGH003", "PYI" ]
 lint.ignore = [
     # Ruff warns that this conflicts with the formatter.
     "COM812",
@@ -125,6 +126,7 @@ lint.ignore = [
     # Allow 'assert' as we use it for tests.
     "S101",
 ]
+lint.explicit-preview-rules = true
 lint.per-file-ignores."doccmd_*.py" = [
     # Allow our chosen docstring line-style - pydocstringformatter handles
     # formatting but docstrings in docs may not match this style.
@@ -141,6 +143,7 @@ lint.flake8-tidy-imports.banned-api."typing.cast".msg = """\
     typing.cast is banned: use explicit type narrowing or a typed variable instead.\
     """
 lint.pydocstyle.convention = "google"
+lint.preview = true
 
 [tool.pylint]
 # Disable the message, report, category or checker with the given id(s). You
@@ -353,8 +356,21 @@ enableTypeIgnoreComments = false
 reportUnnecessaryTypeIgnoreComment = true
 
 [tool.ty]
+rules.blanket-ignore-comment = "error"
+rules.division-by-zero = "warn"
+rules.dynamic-function-decorator-return = "error"
+rules.missing-type-argument = "error"
+rules.possibly-missing-attribute = "warn"
+rules.possibly-missing-import = "warn"
+rules.possibly-unresolved-reference = "warn"
+rules.unsound-assignment = "error"
+rules.unsound-return-statement = "error"
+rules.unsound-yield = "error"
+rules.unsupported-dynamic-base = "warn"
 terminal.error-on-warning = true
 analysis.respect-type-ignore-comments = false
+analysis.strict-equality-semantics = true
+analysis.strict-generic-narrowing = true
 
 [tool.pytest]
 log_cli = true

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -17,5 +17,6 @@ reportUnknownVariableType
 rst
 str
 tuple
+ty
 untyped
 whitespace

--- a/src/sphinx_substitution_extensions/__init__.py
+++ b/src/sphinx_substitution_extensions/__init__.py
@@ -170,7 +170,7 @@ def _get_delimiter_pairs(
         )
         delimiter_pairs = {*delimiter_pairs, new_delimiter_pair}
 
-    return delimiter_pairs
+    return delimiter_pairs  # ty: ignore[unsound-return-statement]
 
 
 @beartype
@@ -399,7 +399,7 @@ class SubstitutionCodeRole:
     ) -> tuple[list[Node], list[system_message]]:
         """Replace placeholders with given variables."""
         settings = inliner.document.settings
-        env: BuildEnvironment = settings.env
+        env: BuildEnvironment = settings.env  # ty: ignore[unsound-assignment]
         myst_config = _get_myst_config(context=inliner)
         substitution_defs = _get_substitution_defs(
             env=env,
@@ -606,7 +606,7 @@ class SubstitutionInclude(Include):
     @override
     def run(self) -> list[Node]:
         """Replace placeholders in the path and/or included content."""
-        env: BuildEnvironment | None = self.state.document.settings.env
+        env: BuildEnvironment | None = self.state.document.settings.env  # ty: ignore[unsound-assignment]
 
         if env is None:
             return list(DocutilsInclude.run(self=self))
@@ -720,7 +720,7 @@ class SubstitutionImage(Image):
     @override
     def run(self) -> list[Node]:
         """Replace placeholders with given variables in the image path."""
-        env: BuildEnvironment = self.state.document.settings.env
+        env: BuildEnvironment = self.state.document.settings.env  # ty: ignore[unsound-assignment]
         config: Config = env.config
         myst_config = _get_myst_config(context=self.state)
 


### PR DESCRIPTION
## Summary

- enable Astral's strictest recommended Ty rules and analysis semantics
- enable the recommended Ruff ANN, PYI, and PGH003 families
- keep preview rules explicit so existing select-all configurations do not activate unrelated preview diagnostics
- narrow straightforward typed collections and use diagnostic-specific Ty suppressions at intentionally untyped framework/data boundaries

Configuration reference: https://docs.astral.sh/ty/coming-from-mypy-or-pyright/#recommended-configuration

## Validation

- ty check
- ruff check .
- full pre-commit hook suite
