### PR TITLE
Use Snapper 0.11.1 and remove the fenced-example exclusion

### DIFF
--- a/.snapperrc.toml
+++ b/.snapperrc.toml
@@ -1,4 +1,0 @@
-# This file contains a markup construct that Snapper 0.11.0 does not yet preserve.
-ignore = [
-  "sample/source/markdown_sample.md",
-]

--- a/prek.toml
+++ b/prek.toml
@@ -379,7 +379,7 @@ hooks = [
   {
     id = "snapper",
     name = "snapper",
-    entry = "uv run --group=dev snapper --max-width 0 --in-place",
+    entry = "uv run --group=dev snapper --native --max-width 0 --in-place",
     language = "python",
     types_or = [
       "rst",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dev = [
     # use it to lint shell commands in GitHub workflow files.
     "shellcheck-py==0.11.0.1",
     "shfmt-py==4.1.0",
-    "snapper-fmt==0.11.0",
+    "snapper-fmt==0.11.1",
     "sphinx>=9,<10",
     "sphinx-lint==1.0.2",
     "sphinx-toolbox==4.3.0",


### PR DESCRIPTION
## Summary

- upgrade `snapper-fmt` from 0.11.0 to 0.11.1
- remove the Markdown sample exclusion now that TurtleTech-ehf/snapper#48 is released
- force Snapper's native parser so hook behavior does not depend on whether Pandoc is installed

## Validation

- `prek run snapper --all-files`
- `prek run check-toml --all-files`
- `uv lock --check`
- `git diff --check origin/main...HEAD`