### PR TITLE
Type MyST delimiter pairs precisely

### DIFF
--- a/src/sphinx_substitution_extensions/__init__.py
+++ b/src/sphinx_substitution_extensions/__init__.py
@@ -53,21 +53,25 @@ SubstitutionValue: TypeAlias = (
     | dict[str, "SubstitutionValue"]
 )
 Substitutions: TypeAlias = dict[str, SubstitutionValue]
-_PAIR_LENGTH = 2
 
 
-def _is_object_sequence(
+def _is_delimiter_sequence(
     value: object, /
 ) -> TypeGuard[list[object] | tuple[object, ...]]:
-    """Return whether a value is a sequence with unchecked entries."""
+    """Return whether a delimiter value is a list or tuple."""
     return isinstance(value, (list, tuple))
 
 
-def _is_object_pair(
-    value: object, /
-) -> TypeGuard[list[object] | tuple[object, ...]]:
-    """Return whether a value is a pair with unchecked entries."""
-    return _is_object_sequence(value) and len(value) == _PAIR_LENGTH
+def _delimiter_pair(*, value: object) -> tuple[str, str]:
+    """Return a validated pair of string delimiters."""
+    assert _is_delimiter_sequence(value)
+    pair_length = 2
+    assert len(value) == pair_length
+    opening_delimiter: object = value[0]
+    closing_delimiter: object = value[1]
+    assert isinstance(opening_delimiter, str)
+    assert isinstance(closing_delimiter, str)
+    return opening_delimiter, closing_delimiter
 
 
 @beartype
@@ -179,10 +183,9 @@ def _get_delimiter_pairs(
             configured_delimiters: object = config.myst_sub_delimiters
         else:
             configured_delimiters = myst_config.sub_delimiters
-        assert _is_object_pair(configured_delimiters)
-        opening_delimiter, closing_delimiter = configured_delimiters
-        assert isinstance(opening_delimiter, str)
-        assert isinstance(closing_delimiter, str)
+        opening_delimiter, closing_delimiter = _delimiter_pair(
+            value=configured_delimiters,
+        )
         new_delimiter_pair = (
             opening_delimiter + opening_delimiter,
             closing_delimiter + closing_delimiter,

--- a/src/sphinx_substitution_extensions/__init__.py
+++ b/src/sphinx_substitution_extensions/__init__.py
@@ -2,7 +2,7 @@
 
 from importlib.metadata import version
 from pathlib import Path
-from typing import ClassVar, TypeAlias, TypeGuard
+from typing import ClassVar, TypeAlias
 from unittest.mock import patch
 
 from beartype import beartype
@@ -55,23 +55,13 @@ SubstitutionValue: TypeAlias = (
 Substitutions: TypeAlias = dict[str, SubstitutionValue]
 
 
-def _is_delimiter_sequence(
-    value: object, /
-) -> TypeGuard[list[object] | tuple[object, ...]]:
-    """Return whether a delimiter value is a list or tuple."""
-    return isinstance(value, (list, tuple))
-
-
 def _delimiter_pair(*, value: object) -> tuple[str, str]:
     """Return a validated pair of string delimiters."""
-    assert _is_delimiter_sequence(value)
-    pair_length = 2
-    assert len(value) == pair_length
-    opening_delimiter: object = value[0]
-    closing_delimiter: object = value[1]
-    assert isinstance(opening_delimiter, str)
-    assert isinstance(closing_delimiter, str)
-    return opening_delimiter, closing_delimiter
+    assert isinstance(value, (list, tuple))
+    assert isinstance(value[0], str)
+    assert isinstance(value[1], str)
+    assert value[2:] == value[:0]
+    return value[0], value[1]
 
 
 @beartype


### PR DESCRIPTION
## Summary

- replace generic object-sequence guards with one delimiter-pair boundary that returns two strings
- validate the sequence shape and element types without an uncovered impossible branch
- inline the sequence narrowing so no one-use type-guard helper or global length constant is needed

## Validation

- `uv run --group=dev prek run --all-files --hook-stage pre-commit`
- `uv run --group=dev prek run --all-files --hook-stage pre-push`
- `uv run --group=dev pytest -q --cov-fail-under 100 --cov=src/ --cov=tests/ .` (72 passed, 100% coverage)