### PR TITLE
Type MyST parsing contexts explicitly

### DIFF
--- a/newsfragments/1722.change.rst
+++ b/newsfragments/1722.change.rst
@@ -1,0 +1,2 @@
+Type MyST parsing contexts as docutils and MyST context classes instead of
+arbitrary objects.

--- a/newsfragments/1722.change.rst
+++ b/newsfragments/1722.change.rst
@@ -1,2 +1,1 @@
-Type MyST parsing contexts as docutils and MyST context classes instead of
-arbitrary objects.
+Type MyST parsing contexts as docutils and MyST context classes instead of arbitrary objects.

--- a/src/sphinx_substitution_extensions/__init__.py
+++ b/src/sphinx_substitution_extensions/__init__.py
@@ -20,7 +20,7 @@ from docutils.parsers.rst import directives
 from docutils.parsers.rst.directives.images import Image
 from docutils.parsers.rst.directives.misc import Include as DocutilsInclude
 from docutils.parsers.rst.roles import code_role
-from docutils.parsers.rst.states import Inliner
+from docutils.parsers.rst.states import Inliner, RSTState
 from docutils.statemachine import StringList
 from myst_parser.config.main import MdParserConfig
 from myst_parser.mdit_to_docutils.base import DocutilsRenderer
@@ -71,7 +71,9 @@ def _is_object_pair(
 
 
 @beartype
-def _get_myst_config(*, context: object) -> MdParserConfig | None:
+def _get_myst_config(
+    *, context: Inliner | MockInliner | MockState | RSTState
+) -> MdParserConfig | None:
     """Get the effective MyST configuration from a parsing context."""
     if isinstance(context, (MockInliner, MockState)):
         # MyST merges front matter into a document-local configuration before


### PR DESCRIPTION
Replace the MyST configuration helper’s `context: object` with the four framework context types that reach it: docutils `Inliner`/`RSTState` and MyST `MockInliner`/`MockState`.

All existing directive and role call sites type-check against the union, and runtime behavior is unchanged.

Local verification:
- all five configured type checkers on the extension module
- all repository hook stages
- `uv run pytest`