### PR TITLE
Type substitution option names

### DIFF
--- a/newsfragments/1723.change.rst
+++ b/newsfragments/1723.change.rst
@@ -1,0 +1,1 @@
+Type substitution option collections by the names they contain.

--- a/src/sphinx_substitution_extensions/__init__.py
+++ b/src/sphinx_substitution_extensions/__init__.py
@@ -1,5 +1,6 @@
 """Custom Sphinx extensions."""
 
+from collections.abc import Collection
 from importlib.metadata import version
 from pathlib import Path
 from typing import ClassVar, TypeAlias, TypeGuard
@@ -250,7 +251,7 @@ def _apply_substitutions(
 @beartype
 def _should_apply_substitutions(
     *,
-    options: dict[str, object],
+    options: Collection[str],
     config: Config,
     yes_flag: str,
     no_flag: str,


### PR DESCRIPTION
The substitution decision helper only inspects membership, so accept a collection of option names rather than a dictionary of arbitrary object values. This models the actual requirement and works for every directive option mapping passed by the public extension behavior.

Validation: 72 tests and every applicable pre-commit, pre-push, and manual hook pass.