### PR TITLE
Use precise directive option types

### DIFF
--- a/src/sphinx_substitution_extensions/__init__.py
+++ b/src/sphinx_substitution_extensions/__init__.py
@@ -1,6 +1,6 @@
 """Custom Sphinx extensions."""
 
-from collections.abc import Collection
+from collections.abc import Callable, Collection
 from importlib.metadata import version
 from pathlib import Path
 from typing import ClassVar, TypeAlias
@@ -34,7 +34,7 @@ from sphinx.directives.other import Include
 from sphinx.environment import BuildEnvironment
 from sphinx.errors import SphinxError
 from sphinx.roles import XRefRole
-from sphinx.util.typing import ExtensionMetadata, OptionSpec
+from sphinx.util.typing import ExtensionMetadata
 from typing_extensions import override
 
 from sphinx_substitution_extensions.shared import (
@@ -344,9 +344,9 @@ def _substitute_hyperlink_targets(
 class SubstitutionCodeBlock(CodeBlock):
     """Similar to CodeBlock but replaces placeholders with variables."""
 
-    option_spec: ClassVar[OptionSpec] = (  # pyrefly: ignore [explicit-any]
-        CodeBlock.option_spec.copy()
-    )
+    option_spec: ClassVar[dict[str, Callable[[str], object]]] = dict[
+        str, Callable[[str], object]
+    ](CodeBlock.option_spec)
     option_spec[SUBSTITUTION_OPTION_NAME] = directives.flag
     option_spec[NO_SUBSTITUTION_OPTION_NAME] = directives.flag
 
@@ -469,9 +469,9 @@ class SubstitutionLiteralInclude(LiteralInclude):
     variables.
     """
 
-    option_spec: ClassVar[OptionSpec] = (  # pyrefly: ignore [explicit-any]
-        LiteralInclude.option_spec.copy()
-    )
+    option_spec: ClassVar[dict[str, Callable[[str], object]]] = dict[
+        str, Callable[[str], object]
+    ](LiteralInclude.option_spec)
     option_spec[CONTENT_SUBSTITUTION_OPTION_NAME] = directives.flag
     option_spec[PATH_SUBSTITUTION_OPTION_NAME] = directives.flag
     option_spec[NO_CONTENT_SUBSTITUTION_OPTION_NAME] = directives.flag
@@ -555,7 +555,7 @@ class SubstitutionInclude(Include):
     path.
     """
 
-    option_spec: ClassVar[OptionSpec | None] = {  # pyrefly: ignore [explicit-any]
+    option_spec: ClassVar[dict[str, Callable[[str], object]] | None] = {
         **(Include.option_spec if Include.option_spec is not None else {}),
         CONTENT_SUBSTITUTION_OPTION_NAME: directives.flag,
         PATH_SUBSTITUTION_OPTION_NAME: directives.flag,
@@ -727,7 +727,7 @@ class SubstitutionImage(Image):
     path.
     """
 
-    option_spec: ClassVar[OptionSpec | None] = {  # pyrefly: ignore [explicit-any]
+    option_spec: ClassVar[dict[str, Callable[[str], object]] | None] = {
         **(Image.option_spec if Image.option_spec is not None else {}),
         PATH_SUBSTITUTION_OPTION_NAME: directives.flag,
         NO_PATH_SUBSTITUTION_OPTION_NAME: directives.flag,

--- a/src/sphinx_substitution_extensions/__init__.py
+++ b/src/sphinx_substitution_extensions/__init__.py
@@ -55,6 +55,10 @@ SubstitutionValue: TypeAlias = (
 )
 Substitutions: TypeAlias = dict[str, SubstitutionValue]
 
+# Avoid Any-valued converter results until our minimum Sphinx includes
+# https://github.com/sphinx-doc/sphinx/pull/14672.
+OptionSpec: TypeAlias = dict[str, Callable[[str], object]]
+
 
 def _delimiter_pair(*, value: object) -> tuple[str, str]:
     """Return a validated pair of string delimiters."""
@@ -344,9 +348,7 @@ def _substitute_hyperlink_targets(
 class SubstitutionCodeBlock(CodeBlock):
     """Similar to CodeBlock but replaces placeholders with variables."""
 
-    option_spec: ClassVar[dict[str, Callable[[str], object]]] = dict[
-        str, Callable[[str], object]
-    ](CodeBlock.option_spec)
+    option_spec: ClassVar[OptionSpec] = OptionSpec(CodeBlock.option_spec)
     option_spec[SUBSTITUTION_OPTION_NAME] = directives.flag
     option_spec[NO_SUBSTITUTION_OPTION_NAME] = directives.flag
 
@@ -469,9 +471,7 @@ class SubstitutionLiteralInclude(LiteralInclude):
     variables.
     """
 
-    option_spec: ClassVar[dict[str, Callable[[str], object]]] = dict[
-        str, Callable[[str], object]
-    ](LiteralInclude.option_spec)
+    option_spec: ClassVar[OptionSpec] = OptionSpec(LiteralInclude.option_spec)
     option_spec[CONTENT_SUBSTITUTION_OPTION_NAME] = directives.flag
     option_spec[PATH_SUBSTITUTION_OPTION_NAME] = directives.flag
     option_spec[NO_CONTENT_SUBSTITUTION_OPTION_NAME] = directives.flag
@@ -555,7 +555,7 @@ class SubstitutionInclude(Include):
     path.
     """
 
-    option_spec: ClassVar[dict[str, Callable[[str], object]] | None] = {
+    option_spec: ClassVar[OptionSpec | None] = {
         **(Include.option_spec if Include.option_spec is not None else {}),
         CONTENT_SUBSTITUTION_OPTION_NAME: directives.flag,
         PATH_SUBSTITUTION_OPTION_NAME: directives.flag,
@@ -727,7 +727,7 @@ class SubstitutionImage(Image):
     path.
     """
 
-    option_spec: ClassVar[dict[str, Callable[[str], object]] | None] = {
+    option_spec: ClassVar[OptionSpec | None] = {
         **(Image.option_spec if Image.option_spec is not None else {}),
         PATH_SUBSTITUTION_OPTION_NAME: directives.flag,
         NO_PATH_SUBSTITUTION_OPTION_NAME: directives.flag,


### PR DESCRIPTION
Sphinx exports `OptionSpec` with `Any` converter results, which triggers Pyrefly's `explicit-any` check on our four directive option maps.

Use a shared local `OptionSpec` alias with `object` converter results. A comment above it links to https://github.com/sphinx-doc/sphinx/pull/14672 and explains why we need it until our minimum Sphinx version includes that change. The option maps retain their heterogeneous converter contract without suppressions or casts.

Validation:
- `uv run --group dev prek run --all-files --hook-stage pre-commit`
- `uv run --group dev prek run --all-files --hook-stage pre-push`
- `uv run --group dev pytest -q -o log_cli=false --cov-fail-under=100 --cov=src --cov=tests .` (72 passed; 100% coverage)
