### PR TITLE
Add missing Beartype decorators

### DIFF
--- a/src/sphinx_substitution_extensions/__init__.py
+++ b/src/sphinx_substitution_extensions/__init__.py
@@ -56,6 +56,7 @@ SubstitutionValue: TypeAlias = (
 Substitutions: TypeAlias = dict[str, SubstitutionValue]
 
 
+@beartype
 def _delimiter_pair(*, value: object) -> tuple[str, str]:
     """Return a validated pair of string delimiters."""
     assert isinstance(value, (list, tuple))


### PR DESCRIPTION
## Summary

- Add 1 missing @beartype decorators to typed production functions and concrete classes.
- Keep intentional runtime boundaries such as Protocols, framework callbacks, nested closures, and recursive forward-reference models undecorated.

## Validation

- uv run --group dev ruff check .
- uv run --group dev pytest -q
- uv run --group dev prek run --all-files --hook-stage pre-commit
- uv run --group dev prek run --all-files --hook-stage pre-push